### PR TITLE
Fix importing NProgress

### DIFF
--- a/assets/cms/js/base.js
+++ b/assets/cms/js/base.js
@@ -1,7 +1,7 @@
 
 // Import required libraries.
 import * as _ from 'underscore';
-import NProgress from 'NProgress';
+import NProgress from 'nprogress';
 import PNotify from 'pnotify/dist/es/PNotify';
 
 window.NProgress = NProgress;

--- a/assets/documents/js/frontend.js
+++ b/assets/documents/js/frontend.js
@@ -1,4 +1,4 @@
-import NProgress from 'NProgress';
+import NProgress from 'nprogress';
 import 'jquery-ui/ui/widgets/dialog';
 import '../../cms/js/legacy-dialog';
 import '../../cms/js/ajax-request/base';


### PR DESCRIPTION
On case-sensitive operating systems, we have this error:
```
ERROR in ./node_modules/@concretecms/bedrock/assets/cms/js/base.js
Module not found: Error: Can't resolve 'NProgress'
```
Let's fix this