### PR TITLE
Add stylelint for linting against our required style

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "stylelint-config-sass-guidelines",
+  "rules": {
+    "selector-max-id": 1,
+    "selector-no-qualifying-type": null,
+    "color-named": null,
+    "max-nesting-depth": null,
+    "selector-max-compound-selectors": 5
+  }
+}

--- a/assets/account/js/frontend/components/Avatar/Avatar.scss
+++ b/assets/account/js/frontend/components/Avatar/Avatar.scss
@@ -1,17 +1,17 @@
 img {
-    max-width: inherit;
-    min-width: inherit;
-    top: 0;
-    left: 0;
+  left: 0;
+  max-width: inherit;
+  min-width: inherit;
+  top: 0;
 }
 
 .shadow {
-    top: 1px;
-    left: 1px;
-    opacity: 0.3;
-    z-index: 1;
-    position: absolute;
-    box-shadow: 0 0 10px black;
-    outline: solid 1px #333;
-    box-sizing: border-box;
+  box-shadow: 0 0 10px black;
+  box-sizing: border-box;
+  left: 1px;
+  opacity: 0.3;
+  outline: solid 1px #333;
+  position: absolute;
+  top: 1px;
+  z-index: 1;
 }

--- a/assets/account/js/frontend/components/Avatar/Cropper.scss
+++ b/assets/account/js/frontend/components/Avatar/Cropper.scss
@@ -1,129 +1,136 @@
- .ccm-avatar-creator-container {
+/* stylelint-disable property-no-vendor-prefix, property-no-unkown */
+.ccm-avatar-creator-container {
+  position: relative;
+
+  .ccm-avatar-actions {
+    position: absolute;
+    z-index: 20000;
+
+    > a {
+      display: inline-block;
+      height: 16px;
+      opacity: 0.3;
+      text-align: center;
+      text-decoration: none;
+      transition: all 0.5s;
+      width: 50%;
+
+      &:hover {
+        opacity: 1;
+      }
+
+      &::before {
+        font-family: FontAwesome;
+        font-size: 16px;
+        text-align: center;
+      }
+
+      &.ccm-avatar-cancel {
+        color: #ff4136;
+        float: right;
+
+        &::before {
+          content: '\f00d';
+        }
+      }
+
+      &.ccm-avatar-okay {
+        color: #3d9970;
+
+        &::before {
+          content: '\f00c';
+        }
+      }
+    }
+  }
+
+  .ccm-avatar-creator {
+    border: solid 1px #999;
+    overflow: hidden;
     position: relative;
+    transition: all 0.3s;
+    z-index: 10000;
 
-    .ccm-avatar-actions {
-        z-index: 20000;
-        position: absolute;
-
-        > a {
-            width: 50%;
-            height: 16px;
-            display: inline-block;
-            text-align: center;
-            opacity: 0.3;
-            transition: all 0.5s;
-            text-decoration: none;
-
-            &:hover {
-                opacity: 1;
-            }
-
-            &:before {
-                font-size: 16px;
-                font-family: FontAwesome;
-                text-align: center;
-            }
-
-            &.ccm-avatar-cancel {
-                float: right;
-                color: #FF4136;
-                &:before {
-                    content: '\f00d';
-                }
-            }
-
-            &.ccm-avatar-okay {
-                color: #3D9970;
-                &:before {
-                    content: '\f00c';
-                }
-            }
-        }
+    > img.ccm-avatar-current {
+      display: inline;
+      height: 100%;
+      width: 100%;
+      z-index: 998;
     }
 
-    .ccm-avatar-creator {
-        border: solid 1px #999;
-        transition: all 0.3s;
-        z-index: 10000;
-        overflow: hidden;
-        position: relative;
-
-        > img.ccm-avatar-current {
-            z-index:998;
-            display:inline;
-            width: 100%;
-            height: 100%;
-        }
-
-        > div.saving {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(127,219,255, 0.5);
-            font-weight:bolder;
-            font-size: 16px;
-            text-align: center;
-            color: #111111;
-        }
-
-        &:before {
-            transition: all 0.3s;
-            content: '\f093';
-            font-family: FontAwesome;
-            opacity: 0;
-            font-size: 16px;
-            margin: 0 auto;
-            padding-top: 50%;
-            line-height: 0%;
-            display: block;
-            width: 100%;
-            text-align: center;
-            height: 100%;
-            vertical-align: middle;
-            color: #3D9970;
-            background-color: rgba(238, 238, 238, 0.8);
-            z-index:999;
-            position: absolute;
-        }
-
-        &.dz-started {
-            &:before {
-                opacity: 1;
-                -webkit-animation: pulse 1s infinite;
-                animation: pulse 1s infinite;
-            }
-        }
-
-        @keyframes pulse {
-            0% {
-                transform: scale(1);
-            }
-            50% {
-                transform: scale(1.3);
-            }
-            100% {
-                transform: scale(1);
-            }
-        }
-
-        &.editing {
-            &:before {
-                display: none;
-            }
-        }
-
-        &.dz-clickable {
-            pointer: cursor;
-        }
-
-        &.dz-clickable:hover, &.dz-drag-hover {
-            border-color: #3D9970;
-            box-shadow: 0 0 20px -10px #2ECC40;
-            &:before {
-                opacity: 1
-            }
-        }
+    > div.saving {
+      background: rgba(127, 219, 255, 0.5);
+      color: #111;
+      font-size: 16px;
+      font-weight: bolder;
+      height: 100%;
+      left: 0;
+      position: absolute;
+      text-align: center;
+      top: 0;
+      width: 100%;
     }
+
+    &::before {
+      background-color: rgba(238, 238, 238, 0.8);
+      color: #3d9970;
+      content: '\f093';
+      display: block;
+      font-family: FontAwesome;
+      font-size: 16px;
+      height: 100%;
+      line-height: 0%;
+      margin: 0 auto;
+      opacity: 0;
+      padding-top: 50%;
+      position: absolute;
+      text-align: center;
+      transition: all 0.3s;
+      vertical-align: middle;
+      width: 100%;
+      z-index: 999;
+    }
+
+    &.dz-started {
+      &::before {
+        -webkit-animation: pulse 1s infinite;
+        animation: pulse 1s infinite;
+        opacity: 1;
+      }
+    }
+
+    @keyframes pulse {
+      0% {
+        transform: scale(1);
+      }
+
+      50% {
+        transform: scale(1.3);
+      }
+
+      100% {
+        transform: scale(1);
+      }
+    }
+
+    &.editing {
+      &::before {
+        display: none;
+      }
+    }
+
+    &.dz-clickable {
+      cursor: 'pointer';
+    }
+
+    &.dz-clickable:hover,
+    &.dz-drag-hover {
+      border-color: #3d9970;
+      box-shadow: 0 0 20px -10px #2ecc40;
+
+      &::before {
+        opacity: 1;
+      }
+    }
+  }
 }

--- a/assets/basics/scss/frontend.scss
+++ b/assets/basics/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/basics/scss/frontend/_feature.scss
+++ b/assets/basics/scss/frontend/_feature.scss
@@ -5,6 +5,7 @@ div.ccm-block-feature-item p {
 div.ccm-block-feature-item i {
   margin-right: 10px;
 }
+
 div.ccm-block-feature-item {
   margin-bottom: 40px;
 }

--- a/assets/basics/scss/frontend/_frontend.scss
+++ b/assets/basics/scss/frontend/_frontend.scss
@@ -1,1 +1,1 @@
-@import "feature";
+@import 'feature';

--- a/assets/bedrock/scss/_frontend.scss
+++ b/assets/bedrock/scss/_frontend.scss
@@ -1,21 +1,21 @@
 // 01. Bootstrap Functions go first.
-@import "~bootstrap/scss/functions";
+@import '~bootstrap/scss/functions';
 
 // 02. Bootstrap overrides, have to be done BEFORE bootstrap.
-@import "./bootstrap-overrides";
+@import './bootstrap-overrides';
 
 // 03. Bootstrap Variables
-@import "~bootstrap/scss/variables";
+@import '~bootstrap/scss/variables';
 
 // 04. Theme variables, some of which can now be based on bootstrap variable/constants/
-@import "./variables";
-@import "~@fortawesome/fontawesome-free/scss/variables";
+@import './variables';
+@import '~@fortawesome/fontawesome-free/scss/variables';
 
 // 05. Utilities
-@import "utilities";
+@import 'utilities';
 
 // 06. Bootstrap
-@import "~bootstrap/scss/bootstrap";
+@import '~bootstrap/scss/bootstrap';
 
 // 07. Theme Grid
-@import "theme-grid";
+@import 'theme-grid';

--- a/assets/bedrock/scss/_utilities.scss
+++ b/assets/bedrock/scss/_utilities.scss
@@ -1,3 +1,3 @@
 // Basic concrete5 utilities
-@import "utilities/z-index";
-@import "utilities/spacing";
+@import 'utilities/z-index';
+@import 'utilities/spacing';

--- a/assets/bedrock/scss/utilities/_spacing.scss
+++ b/assets/bedrock/scss/utilities/_spacing.scss
@@ -2,30 +2,39 @@
 .spacer-row-1 {
   height: $spacer;
 }
+
 .spacer-row-2 {
   height: ($spacer * 2);
 }
+
 .spacer-row-3 {
   height: ($spacer * 3);
 }
+
 .spacer-row-4 {
   height: ($spacer * 4);
 }
+
 .spacer-row-5 {
   height: ($spacer * 5);
 }
+
 .spacer-row-6 {
   height: ($spacer * 6);
 }
+
 .spacer-row-7 {
   height: ($spacer * 7);
 }
+
 .spacer-row-8 {
   height: ($spacer * 8);
 }
+
 .spacer-row-9 {
   height: ($spacer * 9);
 }
+
 .spacer-row-10 {
   height: ($spacer * 10);
 }

--- a/assets/bedrock/scss/utilities/_z-index.scss
+++ b/assets/bedrock/scss/utilities/_z-index.scss
@@ -1,25 +1,32 @@
 // Classes to easily set z-index
 .z-0 {
-  z-index: 0
+  z-index: 0;
 }
+
 .z-1 {
-  z-index: 1
+  z-index: 1;
 }
+
 .z-2 {
-  z-index: 2
+  z-index: 2;
 }
+
 .z-10 {
-  z-index: 10
+  z-index: 10;
 }
+
 .z-100 {
-  z-index: 100
+  z-index: 100;
 }
+
 .z-250 {
-  z-index: 250
+  z-index: 250;
 }
+
 .z-500 {
-  z-index: 500
+  z-index: 500;
 }
+
 .z-1000 {
-  z-index: 1000
+  z-index: 1000;
 }

--- a/assets/boards/scss/frontend.scss
+++ b/assets/boards/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/calendar/scss/frontend.scss
+++ b/assets/calendar/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/calendar/scss/frontend/_frontend.scss
+++ b/assets/calendar/scss/frontend/_frontend.scss
@@ -1,6 +1,6 @@
 // Fullcalendar
-@import "~fullcalendar/dist/fullcalendar.css";
+@import '~fullcalendar/dist/fullcalendar.css';
 
 // Blocks
-@import "calendar/calendar";
-@import "event-list/event-list";
+@import 'calendar/calendar';
+@import 'event-list/event-list';

--- a/assets/calendar/scss/frontend/calendar/_calendar.scss
+++ b/assets/calendar/scss/frontend/calendar/_calendar.scss
@@ -3,7 +3,7 @@
 }
 
 div.ccm-block-calendar-event-dialog-details {
-  background: #FFF;
+  background: #fff;
   margin: 20px auto;
   max-width: 500px;
   padding: 20px;

--- a/assets/calendar/scss/frontend/event-list/_event-list.scss
+++ b/assets/calendar/scss/frontend/event-list/_event-list.scss
@@ -1,19 +1,19 @@
 div.ccm-block-calendar-event-list {
-  margin-bottom: 10px;
   clear: both;
+  margin-bottom: 10px;
 }
 
 div.ccm-block-calendar-event-list-wrapper {
-  margin-bottom: 10px;
   clear: both;
+  margin-bottom: 10px;
 }
 
 
 div.ccm-block-calendar-event-list-event-date {
-  width: 50px;
-  height: 50px;
   float: left;
+  height: 50px;
   margin-right: 10px;
+  width: 50px;
 }
 
 div.ccm-block-calendar-event-list-event-date span {
@@ -22,14 +22,14 @@ div.ccm-block-calendar-event-list-event-date span {
 }
 
 div.ccm-block-calendar-event-list-event-date span:first-child {
-  font-weight: bold;
   background-color: #000;
   color: #fff;
+  font-weight: bold;
 }
 
 
 div.ccm-block-calendar-event-list-event {
-  padding-bottom: 10px;
   clear: both;
+  padding-bottom: 10px;
 }
 

--- a/assets/ckeditor/scss/concrete.scss
+++ b/assets/ckeditor/scss/concrete.scss
@@ -1,1 +1,1 @@
-@import "plugins/inline";
+@import 'plugins/inline';

--- a/assets/ckeditor/scss/plugins/_inline.scss
+++ b/assets/ckeditor/scss/plugins/_inline.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .cke_toolgroup {
   a.cke_button__concrete_save {
     background-color: #337ab7;
@@ -28,12 +29,12 @@
   }
 }
 
-.cke_editable:before,
-.cke_editable:after {
-  content: "";
+.cke_editable::before,
+.cke_editable::after {
+  content: '';
   display: table;
 }
 
-.cke_editable:after {
+.cke_editable::after {
   clear: both;
 }

--- a/assets/cms/scss/_animate.scss
+++ b/assets/cms/scss/_animate.scss
@@ -1,14 +1,15 @@
+/* stylelint-disable property-no-vendor-prefix, at-rule-no-vendor-prefix, selector-class-pattern */
 .animated {
-  -webkit-animation-fill-mode: both;
-  -moz-animation-fill-mode: both;
-  -ms-animation-fill-mode: both;
-  -o-animation-fill-mode: both;
-  animation-fill-mode: both;
   -webkit-animation-duration: 0.5s;
   -moz-animation-duration: 0.5s;
   -ms-animation-duration: 0.5s;
   -o-animation-duration: 0.5s;
   animation-duration: 0.5s;
+  -webkit-animation-fill-mode: both;
+  -moz-animation-fill-mode: both;
+  -ms-animation-fill-mode: both;
+  -o-animation-fill-mode: both;
+  animation-fill-mode: both;
   
   &.hinge {
     -webkit-animation-duration: 0.5s;
@@ -20,49 +21,89 @@
 }
 
 @-webkit-keyframes shake {
-  0%, 100% {
+  0%,
+  100% {
     -webkit-transform: translateX(0);
   }
-  10%, 30%, 50%, 70%, 90% {
+
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
     -webkit-transform: translateX(-10px);
   }
-  20%, 40%, 60%, 80% {
+
+  20%,
+  40%,
+  60%,
+  80% {
     -webkit-transform: translateX(10px);
   }
 }
 
 @-moz-keyframes shake {
-  0%, 100% {
+  0%,
+  100% {
     -moz-transform: translateX(0);
   }
-  10%, 30%, 50%, 70%, 90% {
+
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
     -moz-transform: translateX(-10px);
   }
-  20%, 40%, 60%, 80% {
+
+  20%,
+  40%,
+  60%,
+  80% {
     -moz-transform: translateX(10px);
   }
 }
 
 @-o-keyframes shake {
-  0%, 100% {
+  0%,
+  100% {
     -o-transform: translateX(0);
   }
-  10%, 30%, 50%, 70%, 90% {
+
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
     -o-transform: translateX(-10px);
   }
-  20%, 40%, 60%, 80% {
+
+  20%,
+  40%,
+  60%,
+  80% {
     -o-transform: translateX(10px);
   }
 }
 
 @keyframes shake {
-  0%, 100% {
+  0%,
+  100% {
     transform: translateX(0);
   }
-  10%, 30%, 50%, 70%, 90% {
+
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
     transform: translateX(-10px);
   }
-  20%, 40%, 60%, 80% {
+
+  20%,
+  40%,
+  60%,
+  80% {
     transform: translateX(10px);
   }
 }
@@ -75,48 +116,72 @@
 }
 
 @-webkit-keyframes bounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
     -webkit-transform: translateY(0);
   }
+
   40% {
     -webkit-transform: translateY(-30px);
   }
+
   60% {
     -webkit-transform: translateY(-15px);
   }
 }
 
 @-moz-keyframes bounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
     -moz-transform: translateY(0);
   }
+
   40% {
     -moz-transform: translateY(-30px);
   }
+
   60% {
     -moz-transform: translateY(-15px);
   }
 }
 
 @-o-keyframes bounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
     -o-transform: translateY(0);
   }
+
   40% {
     -o-transform: translateY(-30px);
   }
+
   60% {
     -o-transform: translateY(-15px);
   }
 }
 
 @keyframes bounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
     transform: translateY(0);
   }
+
   40% {
     transform: translateY(-30px);
   }
+
   60% {
     transform: translateY(-15px);
   }
@@ -154,6 +219,7 @@
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
@@ -163,6 +229,7 @@
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
@@ -172,6 +239,7 @@
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
@@ -181,6 +249,7 @@
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
@@ -197,6 +266,7 @@
   0% {
     opacity: 1;
   }
+
   100% {
     opacity: 0;
   }
@@ -206,6 +276,7 @@
   0% {
     opacity: 1;
   }
+
   100% {
     opacity: 0;
   }
@@ -215,6 +286,7 @@
   0% {
     opacity: 1;
   }
+
   100% {
     opacity: 0;
   }
@@ -224,6 +296,7 @@
   0% {
     opacity: 1;
   }
+
   100% {
     opacity: 0;
   }
@@ -404,7 +477,7 @@
 @-webkit-keyframes bounceIn {
   0% {
     opacity: 0;
-    -webkit-transform: scale(.3);
+    -webkit-transform: scale(0.3);
   }
 
   50% {
@@ -413,7 +486,7 @@
   }
 
   70% {
-    -webkit-transform: scale(.9);
+    -webkit-transform: scale(0.9);
   }
 
   100% {
@@ -424,7 +497,7 @@
 @-moz-keyframes bounceIn {
   0% {
     opacity: 0;
-    -moz-transform: scale(.3);
+    -moz-transform: scale(0.3);
   }
 
   50% {
@@ -433,7 +506,7 @@
   }
 
   70% {
-    -moz-transform: scale(.9);
+    -moz-transform: scale(0.9);
   }
 
   100% {
@@ -444,7 +517,7 @@
 @-o-keyframes bounceIn {
   0% {
     opacity: 0;
-    -o-transform: scale(.3);
+    -o-transform: scale(0.3);
   }
 
   50% {
@@ -453,7 +526,7 @@
   }
 
   70% {
-    -o-transform: scale(.9);
+    -o-transform: scale(0.9);
   }
 
   100% {
@@ -464,7 +537,7 @@
 @keyframes bounceIn {
   0% {
     opacity: 0;
-    transform: scale(.3);
+    transform: scale(0.3);
   }
 
   50% {
@@ -473,7 +546,7 @@
   }
 
   70% {
-    transform: scale(.9);
+    transform: scale(0.9);
   }
 
   100% {
@@ -494,7 +567,7 @@
   }
 
   25% {
-    -webkit-transform: scale(.95);
+    -webkit-transform: scale(0.95);
   }
 
   50% {
@@ -504,7 +577,7 @@
 
   100% {
     opacity: 0;
-    -webkit-transform: scale(.3);
+    -webkit-transform: scale(0.3);
   }
 }
 
@@ -514,7 +587,7 @@
   }
 
   25% {
-    -moz-transform: scale(.95);
+    -moz-transform: scale(0.95);
   }
 
   50% {
@@ -524,7 +597,7 @@
 
   100% {
     opacity: 0;
-    -moz-transform: scale(.3);
+    -moz-transform: scale(0.3);
   }
 }
 
@@ -534,7 +607,7 @@
   }
 
   25% {
-    -o-transform: scale(.95);
+    -o-transform: scale(0.95);
   }
 
   50% {
@@ -544,7 +617,7 @@
 
   100% {
     opacity: 0;
-    -o-transform: scale(.3);
+    -o-transform: scale(0.3);
   }
 }
 
@@ -554,7 +627,7 @@
   }
 
   25% {
-    transform: scale(.95);
+    transform: scale(0.95);
   }
 
   50% {
@@ -564,7 +637,7 @@
 
   100% {
     opacity: 0;
-    transform: scale(.3);
+    transform: scale(0.3);
   }
 }
 
@@ -861,77 +934,89 @@
 
 @-webkit-keyframes lightSpeedIn {
   0% {
-    -webkit-transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    -webkit-transform: translateX(100%) skewX(-30deg);
   }
+
   60% {
+    opacity: 1;
     -webkit-transform: translateX(-20%) skewX(30deg);
-    opacity: 1;
   }
+
   80% {
+    opacity: 1;
     -webkit-transform: translateX(0%) skewX(-15deg);
-    opacity: 1;
   }
+
   100% {
-    -webkit-transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    -webkit-transform: translateX(0%) skewX(0deg);
   }
 }
 
 @-moz-keyframes lightSpeedIn {
   0% {
-    -moz-transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    -moz-transform: translateX(100%) skewX(-30deg);
   }
+
   60% {
+    opacity: 1;
     -moz-transform: translateX(-20%) skewX(30deg);
-    opacity: 1;
   }
+
   80% {
+    opacity: 1;
     -moz-transform: translateX(0%) skewX(-15deg);
-    opacity: 1;
   }
+
   100% {
-    -moz-transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    -moz-transform: translateX(0%) skewX(0deg);
   }
 }
 
 @-o-keyframes lightSpeedIn {
   0% {
-    -o-transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    -o-transform: translateX(100%) skewX(-30deg);
   }
+
   60% {
+    opacity: 1;
     -o-transform: translateX(-20%) skewX(30deg);
-    opacity: 1;
   }
+
   80% {
+    opacity: 1;
     -o-transform: translateX(0%) skewX(-15deg);
-    opacity: 1;
   }
+
   100% {
-    -o-transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    -o-transform: translateX(0%) skewX(0deg);
   }
 }
 
 @keyframes lightSpeedIn {
   0% {
-    transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    transform: translateX(100%) skewX(-30deg);
   }
+
   60% {
+    opacity: 1;
     transform: translateX(-20%) skewX(30deg);
-    opacity: 1;
   }
+
   80% {
+    opacity: 1;
     transform: translateX(0%) skewX(-15deg);
-    opacity: 1;
   }
+
   100% {
-    transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    transform: translateX(0%) skewX(0deg);
   }
 }
 
@@ -949,45 +1034,49 @@
 
 @-webkit-keyframes lightSpeedOut {
   0% {
-    -webkit-transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    -webkit-transform: translateX(0%) skewX(0deg);
   }
+
   100% {
-    -webkit-transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    -webkit-transform: translateX(100%) skewX(-30deg);
   }
 }
 
 @-moz-keyframes lightSpeedOut {
   0% {
-    -moz-transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    -moz-transform: translateX(0%) skewX(0deg);
   }
+
   100% {
-    -moz-transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    -moz-transform: translateX(100%) skewX(-30deg);
   }
 }
 
 @-o-keyframes lightSpeedOut {
   0% {
-    -o-transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    -o-transform: translateX(0%) skewX(0deg);
   }
+
   100% {
-    -o-transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    -o-transform: translateX(100%) skewX(-30deg);
   }
 }
 
 @keyframes lightSpeedOut {
   0% {
-    transform: translateX(0%) skewX(0deg);
     opacity: 1;
+    transform: translateX(0%) skewX(0deg);
   }
+
   100% {
-    transform: translateX(100%) skewX(-30deg);
     opacity: 0;
+    transform: translateX(100%) skewX(-30deg);
   }
 }
 

--- a/assets/cms/scss/_base.scss
+++ b/assets/cms/scss/_base.scss
@@ -1,71 +1,71 @@
 // Basics
-@import "./mixins/item-select-list-hover";
-@import "type";
-@import "buttons";
+@import './mixins/item-select-list-hover';
+@import 'type';
+@import 'buttons';
 
 // Support classes
-@import "./animate";
+@import './animate';
 
 // jQuery UI
-@import "~jquery-ui/themes/base/core.css";
-@import "~jquery-ui/themes/base/resizable.css";
-@import "~jquery-ui/themes/base/dialog.css";
-@import "~jquery-ui/themes/base/datepicker.css";
-@import "~jquery-ui/themes/base/draggable.css";
-@import "~jquery-ui/themes/base/sortable.css";
-@import "~jquery-ui/themes/base/slider.css";
-@import "./jquery-ui/theme";
-@import "./jquery-ui/overrides";
+@import '~jquery-ui/themes/base/core.css';
+@import '~jquery-ui/themes/base/resizable.css';
+@import '~jquery-ui/themes/base/dialog.css';
+@import '~jquery-ui/themes/base/datepicker.css';
+@import '~jquery-ui/themes/base/draggable.css';
+@import '~jquery-ui/themes/base/sortable.css';
+@import '~jquery-ui/themes/base/slider.css';
+@import './jquery-ui/theme';
+@import './jquery-ui/overrides';
 
 // Toolbar includes
-@import "./toolbar";
-@import "./intelligent-search";
+@import './toolbar';
+@import './intelligent-search';
 
 // Dialogs
-@import "./dialog";
+@import './dialog';
 
 // Panels
-@import "./panels";
+@import './panels';
 
 // In page editing
-@import "page-areas";
-@import "inline-toolbar";
-@import "layouts";
+@import 'page-areas';
+@import 'inline-toolbar';
+@import 'layouts';
 
 // Style customizer
-@import "./style-customizer";
+@import './style-customizer';
 
 // Progress bar, notifications, HUD, in page help
-@import "./help";
-@import "./hud";
-@import "./nprogress";
+@import './help';
+@import './hud';
+@import './nprogress';
 
 // Search results
-@import "./search";
-@import "./search-v8";
+@import './search';
+@import './search-v8';
 
 // Sitemap
-@import "./sitemap";
+@import './sitemap';
 
 // Fancytree
-@import "~jquery.fancytree/dist/skin-bootstrap/ui.fancytree.css";
+@import '~jquery.fancytree/dist/skin-bootstrap/ui.fancytree.css';
 
 // Help System
-@import "~bootstrap-tourist/bootstrap-tourist.css";
+@import '~bootstrap-tourist/bootstrap-tourist.css';
 
 // File Manager
-@import "./file-manager";
+@import './file-manager';
 
 // Selectize
-@import "~selectize/dist/css/selectize.css";
-@import "./selectize";
+@import '~selectize/dist/css/selectize.css';
+@import './selectize';
 
 // Miscellaneous components
-@import "./tabs";
-@import "./item-selector";
-@import "./item-select-list";
-@import "./permission-grid";
-@import "./tooltips";
-@import "~spectrum-colorpicker/spectrum.css";
-@import "./icons";
-@import "./date-time";
+@import './tabs';
+@import './item-selector';
+@import './item-select-list';
+@import './permission-grid';
+@import './tooltips';
+@import '~spectrum-colorpicker/spectrum.css';
+@import './icons';
+@import './date-time';

--- a/assets/cms/scss/_bootstrap-overrides.scss
+++ b/assets/cms/scss/_bootstrap-overrides.scss
@@ -1,16 +1,16 @@
 /* colors */
 $gray-100: #fafafa;
 $gray-200: #d8d8d8;
-$gray-500: #7C8088;
-$gray-600: #6A6F7B;
-$gray-700: #4C4F56;
+$gray-500: #7c8088;
+$gray-600: #6a6f7b;
+$gray-700: #4c4f56;
 
 
 $cyan: #027893;
-$blue: #4A90E2;
+$blue: #4a90e2;
 $secondary: $gray-500;
-$green: #28A745;
-$red: #C32A2A;
+$green: #28a745;
+$red: #c32a2a;
 $light-blue: #ebf5fb;
 
 /* typography */
@@ -30,29 +30,29 @@ $btn-font-size: 0.9rem;
 $enable-gradients: false;
 
 /* transitions */
-$transition-base: all .25s ease-in-out;
-$transition-fade: opacity .1s ease-in-out;
-$btn-transition: color .25s ease-in-out, background-color .25s ease-in-out, border-color .25s ease-in-out, box-shadow .25s ease-in-out;
+$transition-base: all 0.25s ease-in-out;
+$transition-fade: opacity 0.1s ease-in-out;
+$btn-transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, border-color 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
 
 /* dialogs */
 $modal-xl: 940px;
 $modal-lg: 810px;
 $modal-md: 675px;
 $modal-sm: 420px;
-$modal-header-border-width: 0px;
-$modal-content-border-width: 0px;
-$modal-footer-border-width: 0px;
-$modal-content-border-radius: 0px;
-$modal-content-inner-border-radius: 0px;
+$modal-header-border-width: 0;
+$modal-content-border-width: 0;
+$modal-footer-border-width: 0;
+$modal-content-border-radius: 0;
+$modal-content-inner-border-radius: 0;
 $modal-header-padding-y: 1.25rem;
 $modal-header-padding-x: 1.8rem;
 $modal-title-line-height: 1.25em;
 $modal-inner-padding: 1.8rem;
 $modal-fade-transform: none;
-$modal-transition: .1s ease-in-out;
+$modal-transition: 0.1s ease-in-out;
 
 /* tabs */
-$nav-tabs-border-width: 0px;
+$nav-tabs-border-width: 0;
 $nav-tabs-link-active-color: $gray-700;
 $nav-tabs-link-active-border-color: $blue;
 $nav-tabs-link-hover-border-color: $gray-200;

--- a/assets/cms/scss/_buttons.scss
+++ b/assets/cms/scss/_buttons.scss
@@ -26,6 +26,6 @@ div.ccm-ui {
   }
 
   .btn-default {
-    border: 1px solid #D8D8D8;
+    border: 1px solid #d8d8d8;
   }
 }

--- a/assets/cms/scss/_date-time.scss
+++ b/assets/cms/scss/_date-time.scss
@@ -2,22 +2,29 @@
 /* date controls */
 .ccm-input-time-wrapper {
   select {
-    width: auto;
     margin-right: 4px !important;
+    width: auto;
+
     &:last-child {
       margin-right: 0 !important;
     }
   }
+
   .separator {
     margin-right: 4px;
   }
 }
-.ccm-input-date {width: auto ; margin-right: 4px !important;}
+
+.ccm-input-date { margin-right: 4px !important;
+  width: auto;}
+
 div.popover {
   .ccm-input-date-wrapper {
     margin-bottom: 10px;
   }
-  .ccm-input-time-wrapper, .ccm-input-date-wrapper {
+
+  .ccm-input-time-wrapper,
+  .ccm-input-date-wrapper {
     display: block;
   }
 }
@@ -31,8 +38,8 @@ div.ccm-date-time-duration-wrapper {
 
   a.ccm-date-time-duration-delete {
     position: absolute;
-    top: 0px;
-    right: 0px;
+    right: 0;
+    top: 0;
     z-index: 2000;
   }
 }

--- a/assets/cms/scss/_dialog.scss
+++ b/assets/cms/scss/_dialog.scss
@@ -1,13 +1,12 @@
 div.ccm-ui {
-  
   .modal-dialog {
     box-shadow: $modal-box-shadow;
   }
   
   .modal-header {
     background-color: $blue;
-    font-weight: 400;
     color: $modal-title-color;
+    font-weight: 400;
     
     .modal-title {
       font-size: $modal-title-font-size;
@@ -16,15 +15,15 @@ div.ccm-ui {
     }
     
     button {
+      color: white;
 
       opacity: 1;
-      color: white;
       transition: color 0.1s ease-in-out;
 
       &:not(:disabled):not(.disabled) {
         @include hover-focus() {
-          opacity: 1;
           color: $gray-600;
+          opacity: 1;
 
           svg {
             fill: $gray-600;
@@ -34,10 +33,10 @@ div.ccm-ui {
       }
       
       svg {
-        width: 24px;
-        height: 24px;
         fill: white;
+        height: 24px;
         transition: fill 0.1s ease-in-out;
+        width: 24px;
       }
 
     }

--- a/assets/cms/scss/_file-manager.scss
+++ b/assets/cms/scss/_file-manager.scss
@@ -1,12 +1,13 @@
-
+/* stylelint-disable property-no-vendor-prefix, function-url-quotes, selector-class-pattern */
 /**
  * Preview Image Popover
  */
 //since the popover must be placed in body to prevent clipping in a modal situation we need to include not namespaced
 // styles here and adjust the z-Index
 .popover {
-  z-index: $index-level-dialog-content-click-proxy;
   max-width: none;
+  z-index: $index-level-dialog-content-click-proxy;
+
   img {
     max-width: 75vw;
   }
@@ -27,21 +28,24 @@ table.ccm-file-manager-list {
   img.ccm-file-manager-list-thumbnail,
   img.ccm-generic-thumbnail {
     &.ccm-thumbnail-small {
-      width: 30px;
       height: 30px;
+      width: 30px;
     }
-    &.ccm-thumbnail-full{
-      width: auto;
+
+    &.ccm-thumbnail-full {
       height: auto;
+      width: auto;
     }
   }
+
   td.ccm-search-results-icon {
     i {
-      margin-top: 7px;
-      margin-bottom: 7px;
       display: inline-block;
+      margin-bottom: 7px;
+      margin-top: 7px;
     }
   }
+
   .dropdown {
     text-align: right;
   }
@@ -52,9 +56,9 @@ table.ccm-file-manager-list {
  * Download iframe
  */
 #ccm-file-manager-download-target {
-  width: 0px;
-  height: 0px;
+  height: 0;
   visibility: hidden;
+  width: 0;
 }
 
 
@@ -62,19 +66,19 @@ table.ccm-file-manager-list {
  * Select in page
  */
 div.ccm-file-selector {
-  border-radius: 2px;
-  color: #ffffff;
   background-color: $blue;
+  border-radius: 2px;
+  color: #fff;
+  cursor: pointer;
   text-align: center;
   transition: 0.1s linear all;
-  cursor: pointer;
 
   &.ccm-parent-menu-item-hover,
   &.ccm-parent-menu-item-active,
   &:hover {
-    cursor: pointer;
-    outline: 0px;
     background-color: #2a6496;
+    cursor: pointer;
+    outline: 0;
   }
 
   div.ccm-file-selector-choose-new {
@@ -89,12 +93,12 @@ div.ccm-file-selector {
     padding: 8px;
     text-align: left;
 
-    div.ccm-file-selector-file-selected-thumbnail {
-      margin-right: 10px; float: left;
+    div.ccm-file-selector-file-selected-thumbnail { float: left;
+      margin-right: 10px;
 
       img {
-        max-width: 60px;
         max-height: 60px;
+        max-width: 60px;
       }
     }
 
@@ -108,8 +112,8 @@ div.ccm-file-selector {
  * Menuing
  */
 #ccm-menu-click-proxy.ccm-file-manager-menu-item-hover {
-  z-index: $index-level-dialog-content-click-proxy;
   background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+  z-index: $index-level-dialog-content-click-proxy;
 }
 
 div#ccm-popover-menu-container {
@@ -123,55 +127,71 @@ div#ccm-popover-menu-container {
  */
 div.ccm-file-manager-import-files {
   form.dropzone {
+
+    border: 2px dashed #09f;
     transition: 0.1s linear all;
+
     .dz-default.dz-message {
       span {
+        color: #999;
+        display: block;
         font-size: $font-size-base * 2;
         -webkit-font-smoothing: antialiased;
         font-weight: normal;
-        display: block;
-        color: #999;
       }
     }
 
     &.drag-hover {
-      background-color: rgba(102,175,233,0.6);
+      background-color: rgba(102, 175, 233, 0.6);
+
       span {
         color: #999;
       }
     }
-
-    border: 2px dashed #09f;
   }
-  textarea[name="url_upload"] {
+
+  textarea[name='url_upload'] {
     resize: vertical;
     white-space: nowrap;
   }
-  form.dropzone, textarea[name="url_upload"] {
+
+  form.dropzone,
+  textarea[name='url_upload'] {
     min-height: 340px;
   }
+
   table.incoming_file_table {
-    .incoming_file_table-checkbox, .incoming_file_table-thumbnail, .incoming_file_table-filename, .incoming_file_table-size {
-        vertical-align: middle;
-    }
-    td.incoming_file_table-checkbox, td.incoming_file_table-thumbnail {
-        text-align: center;
-    }
-    td.incoming_file_table-filename {
-        text-align: left;
-    }
-    td.incoming_file_table-size {
-        text-align: right;
-    }
-    .incoming_file_table-checkbox {
-        width: 1px;
-    }
-    .incoming_file_table-thumbnail {
-        width: 48px;
-    }
+    .incoming_file_table-checkbox,
+    .incoming_file_table-thumbnail,
+    .incoming_file_table-filename,
     .incoming_file_table-size {
-        width: 1px;
-        white-space: nowrap;
+      vertical-align: middle;
+    }
+
+    td.incoming_file_table-checkbox,
+    td.incoming_file_table-thumbnail {
+      text-align: center;
+    }
+
+    td.incoming_file_table-filename {
+      text-align: left;
+    }
+
+    td.incoming_file_table-size {
+      text-align: right;
+    }
+
+    .incoming_file_table-checkbox {
+      width: 1px;
+    }
+
+    .incoming_file_table-thumbnail {
+      width: 48px;
+    }
+
+    .incoming_file_table-size {
+      white-space: nowrap;
+      width: 1px;
     }
   }
 }
@@ -181,32 +201,36 @@ div.ccm-file-manager-import-files {
  */
 .ccm-ui {
   .ccm-image-thumbnail-card {
-    padding: 12px;
-    margin-bottom: 20px;
     border: 1px solid #ddd;
     border-radius: 4px;
+    margin-bottom: 20px;
+    padding: 12px;
 
     hr.ccm-image-thumbnail-divider {
       margin: 15px -12px;
     }
   }
+
   .ccm-file-manager-image-thumbnail {
-    margin-bottom: 0px;
+    background-color: #efefef;
+    color: #999;
+    font-weight: 300;
+    margin-bottom: 0;
     padding: 20px;
     text-align: center;
-    background-color: #efefef;
-    font-weight: 300;
-    color: #999;
   }
+
   .ccm-image-thumbnail-display-name {
     min-height: 40px;
   }
+
   .ccm-image-thumbnail-display-name h4 {
-    margin-top: 0px;
+    margin-top: 0;
   }
+
   .ccm-image-thumbnail-dimensions {
+    color: #999;
     display: block;
     margin-bottom: 10px;
-    color: #999;
   }
 }

--- a/assets/cms/scss/_help.scss
+++ b/assets/cms/scss/_help.scss
@@ -1,33 +1,38 @@
+/* stylelint-disable property-no-vendor-prefix */
 //@import "../../vendor/tourist/tourist.less";
 
 div.ccm-dialog-help-item {
   margin-bottom: 30px;
-  a:focus, a:active {
+
+  a:focus,
+  a:active {
     outline: none;
     text-decoration: none;
   }
+
   ol.breadcrumb {
-    padding: 0px;
     background: none;
+    padding: 0;
 
     > li + li::before {
-      content: "|\00a0";
       color: #999;
-      padding: 0px 5px;
+      content: '|\00a0';
+      padding: 0 5px;
     }
   }
 }
 
 
 ol.ccm-dialog-help-item-icon-row {
-  padding: 0px;
-  margin: 0px 0px 10px 0px;
+  margin: 0 0 10px;
+  padding: 0;
+
   li {
     display: inline-block;
     margin-right: 10px;
 
     i {
-      opacity: .5;
+      opacity: 0.5;
     }
   }
 }
@@ -35,11 +40,11 @@ ol.ccm-dialog-help-item-icon-row {
 /** toolbar guide */
 div#ccm-toolbar {
   .tour-highlight {
-
-    a, &.ccm-toolbar-search {
-      background-color: #D6E6EE;
+    a,
+    &.ccm-toolbar-search {
       @include gradient-y(#D6E6EE, #B8DCEE);
-      color: #136CC0;
+      background-color: #d6e6ee;
+      color: #136cc0;
     }
 
   }
@@ -52,147 +57,156 @@ div#ccm-toolbar {
  * Help launcher
  */
 div.ccm-notification-help-launcher {
+
+  -webkit-font-smoothing: antialiased;
   position: fixed;
+  right: 0;
   top: 82px;
-  right: 0px;
+  transition: transform cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
   z-index: $index-level-page-help;
 
   div.ccm-panel-detail-content & {
     z-index: $index-level-panel-help;
   }
 
-  -webkit-font-smoothing: antialiased;
-  transition: transform cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
-
   html.ccm-panel-open.ccm-panel-right & {
     transform: translate(-320px, 0);
   }
 
   a {
-    border-top-left-radius: 3px;
+
+    -webkit-animation-duration: 0.2s;
+    -moz-animation-duration: 0.2s;
+    -ms-animation-duration: 0.2s;
+    -o-animation-duration: 0.2s;
+    animation-duration: 0.2s;
+    background-color: #335b8a;
     border-bottom-left-radius: 3px;
-    background-color: #335B8A;
+    border-top-left-radius: 3px;
     color: #fff;
     display: block;
     height: 40px;
-    width: 40px;
     transition: all 0.1s ease-in-out;
-
-    -webkit-animation-duration:0.2s;
-    -moz-animation-duration:0.2s;
-    -ms-animation-duration:0.2s;
-    -o-animation-duration:0.2s;
-    animation-duration:0.2s;
+    width: 40px;
 
   }
 
-  a:hover, a:active, a:focus {
-    color: #fff;
+  a:hover,
+  a:active,
+  a:focus {
     background-color: #163251;
+    color: #fff;
   }
 
   i {
-    margin-left: 9px;
-    vertical-align: middle;
     font-size: $font-size-lg;
     font-weight: normal;
     line-height: $line-height-lg;
+    margin-left: 9px;
+    vertical-align: middle;
   }
 }
 
 div.ccm-notification-help {
+
+  -webkit-animation-duration: 0.2s;
+  -moz-animation-duration: 0.2s;
+  -ms-animation-duration: 0.2s;
+  -o-animation-duration: 0.2s;
+  animation-duration: 0.2s;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
   display: none;
+  -webkit-font-smoothing: antialiased;
+
+  position: fixed;
+  right: 0;
+  top: 83px;
+
+  transition: transform cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
+  z-index: $index-level-page-help;
 
   div.ccm-panel-detail-content & {
     margin-top: -28px; // not sure why – some of the style in these panels gets a little weird.
   }
 
-  -webkit-animation-duration:0.2s;
-  -moz-animation-duration:0.2s;
-  -ms-animation-duration:0.2s;
-  -o-animation-duration:0.2s;
-  animation-duration:0.2s;
-  -webkit-font-smoothing: antialiased;
-
-  transition: transform cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
-
   html.ccm-panel-open.ccm-panel-right & {
     transform: translate(-320px, 0);
   }
-
-  position: fixed;
-  right: 0px;
-  top: 83px;
-  border-bottom-right-radius:0px;
-  border-top-right-radius: 0px;
-  z-index: $index-level-page-help;
 
 }
 
 
 div.ccm-notification-help {
 
-  max-width: 90%;
+
+  background-color: rgba(19, 72, 125, 0.9);
+  border-radius: 3px;
+  color: #adeef7;
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
-  z-index: $index-level-hud;
   -webkit-font-smoothing: antialiased;
-  border-radius: 3px;
+
+  max-width: 90%;
+  z-index: $index-level-hud;
+
   i.ccm-notification-icon {
-    position: absolute;
-    top: 20px;
     border: 1px solid rgba(255, 255, 255, 0.2);
-    padding: 11px 12px;
-    width: 40px;
-    height: 40px;
-    text-align: center;
-    left: 20px;
     border-radius: 40px;
+    height: 40px;
+    left: 20px;
+    padding: 11px 12px;
+    position: absolute;
+    text-align: center;
+    top: 20px;
+    width: 40px;
   }
 
   div.ccm-notification-inner {
-    width: 360px;
     max-width: 100%;
     padding: 30px 30px 30px 80px;
+    width: 360px;
   }
 
-
-  background-color: rgba(19, 72, 125, 0.9);
-  color: #adeef7;
   h3 {
     color: #fff;
     font-size: $font-size-base * 1.2;
     font-weight: 300;
-    margin: 0px 0px 10px 0px;
-    padding: 0px;
+    margin: 0 0 10px;
+    padding: 0;
   }
+
   .ccm-notification-icon {
     color: #fff;
   }
 
   div.ccm-notification-actions {
-    font-size: $font-size-sm;
-    font-weight: 400;
     background-color: rgba(17, 47, 76, 0.9);
-    border-top: 1px solid #002a53;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
+    border-top: 1px solid #002a53;
+    font-size: $font-size-sm;
+    font-weight: 400;
     text-align: right;
+
     a {
-      display: inline-block;
-      text-align: center;
-      padding: 6px 10px 6px 10px;
-      margin-left: 0px;
       border-left: 1px solid #002a53;
       color: #88aee7;
+      display: inline-block;
+      margin-left: 0;
+      padding: 6px 10px;
+      text-align: center;
+
       &.ccm-notification-actions-dismiss-single {
-        color: #ffff00;
+        color: #ff0;
       }
 
     }
-    a, a:hover {
-      text-decoration: none;
+
+    a,
+    a:hover {
       color: #fff;
+      text-decoration: none;
     }
 
   }

--- a/assets/cms/scss/_hud.scss
+++ b/assets/cms/scss/_hud.scss
@@ -1,28 +1,28 @@
 .ccm-notification {
-  max-width: 90%;
+  border-radius: 3px;
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
   -webkit-font-smoothing: antialiased;
-  border-radius: 3px;
-  padding: 30px 30px 30px 0px;
+  max-width: 90%;
+  padding: 30px 30px 30px 0;
   top: 45px;
 
   div.ui-pnotify-icon {
-    position: absolute;
-    top: 20px;
     border: 1px solid rgba(255, 255, 255, 0.2);
-    padding: 11px 12px;
-    width: 40px;
-    height: 40px;
-    text-align: center;
-    left: 20px;
     border-radius: 40px;
+    height: 40px;
+    left: 20px;
+    padding: 11px 12px;
+    position: absolute;
+    text-align: center;
+    top: 20px;
+    width: 40px;
   }
 
   h4.ui-pnotify-title {
     font-weight: 300;
-    margin: 0px 0px 10px 70px;
-    padding: 0px;
+    margin: 0 0 10px 70px;
+    padding: 0;
   }
 
   div.ui-pnotify-text {
@@ -32,11 +32,11 @@
   span.ccm-notification-closer {
 
     position: absolute;
-    top: 0px;
     right: 5px;
+    top: 0;
 
-    &:after {
-      content: "\f00d";
+    &::after {
+      content: '\f00d';
       font-family: FontAwesome;
     }
   }
@@ -44,9 +44,10 @@
   div.ccm-notification-inner-buttons {
     margin-top: 10px;
 
-    a, button {
-      border: 0px;
-      outline: 0px;
+    a,
+    button {
+      border: 0;
+      outline: 0;
     }
 
     .btn-default {
@@ -68,28 +69,32 @@
 div.ccm-notification-info {
   background-color: rgba(19, 72, 125, 0.9);
   color: #adeef7;
+
   h3 {
     color: #fff;
   }
+
   .ccm-notification-icon {
     color: #fff;
   }
 }
 
 div.ccm-notification-success {
-  color: #ffffff;
   background-color: rgba(15, 190, 102, 0.9);
+  color: #fff;
+
   h3 {
     color: #fff;
   }
+
   i {
     color: #fff;
   }
 }
 
 div.ccm-notification-danger {
+  background-color: rgba(190, 62, 62, 0.9);
   color: #fff;
-  background-color: rgba(190, 62, 62, 0.90);
 }
 
 

--- a/assets/cms/scss/_icons.scss
+++ b/assets/cms/scss/_icons.scss
@@ -4,7 +4,7 @@ a.icon-link i.fa {
 }
 
 a.icon-link.launch-tooltip {
-  border-bottom: 0px;
+  border-bottom: 0;
 }
 
 a.icon-link:hover {

--- a/assets/cms/scss/_inline-toolbar.scss
+++ b/assets/cms/scss/_inline-toolbar.scss
@@ -1,40 +1,44 @@
 .ccm-inline-toolbar {
-  font-family: Helvetica, Arial, Verdana, Tahoma, sans-serif !important;
-  box-shadow: 0px 0px 6px rgba(200, 200, 200, 0.5);
   border-radius: 3px;
-  z-index: $index-level-inline-toolbar;
-  margin: 0 !important;
-  position: relative;
-  padding: 0px !important;
+  box-shadow: 0 0 6px rgba(200, 200, 200, 0.5);
+  display: table;
+  font-family: Helvetica, Arial, Verdana, Tahoma, sans-serif !important;
+  height: 31px;
   line-height: 0;
   list-style: none;
+  margin: 0 !important;
   opacity: 0;
-  display: table;
-  height: 31px;
+  padding: 0 !important;
+  position: relative;
+  z-index: $index-level-inline-toolbar;
 
+  /* stylelint-disable selector-class-pattern */
   &.redactor_toolbar {
     background: transparent;
   }
+  /* stylelint-enable selector-class-pattern */
 
   > li {
+    background: #fff;
+    border-bottom: 1px solid #c4c4c4;
+    border-right: 1px solid #e1e1e1;
+    border-top: 1px solid #c4c4c4;
+    display: table-cell;
+    font-size: $font-size-base !important;
     list-style: none;
     outline: none;
-    border-top: 1px solid #c4c4c4;
-    border-bottom: 1px solid #c4c4c4;
-    padding: 3px 8px 3px 8px;
-    display: table-cell;
-    border-right: 1px solid #e1e1e1;
+    padding: 3px 8px;
     vertical-align: middle;
-    font-size: $font-size-base !important;
-    background: #fff;
+
     label {
-      font-size: $font-size-sm;
       display: inline;
-      margin: 0px 0px 8px 0px;
+      font-size: $font-size-sm;
+      margin: 0 0 8px;
     }
 
     &.ccm-inline-toolbar-inverse-cell {
       background-color: #555;
+
       a {
         color: #fff;
       }
@@ -44,36 +48,36 @@
   }
 
   > li:first-child {
-    border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
     border-left: 1px solid #c4c4c4;
+    border-top-left-radius: 3px;
   }
 
   > li:last-child {
-    border-right: 0px;
-    border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
+    border-right: 0;
+    border-top-right-radius: 3px;
   }
 
   > li.ccm-inline-toolbar-icon-cell {
-    width: 30px;
-    text-align: center;
-    padding: 0px;
     @include gradient-y(#fff, #f1f1f1);
+    padding: 0;
     position: relative;
+    text-align: center;
+    width: 30px;
   }
 
   > li.ccm-inline-toolbar-icon-cell > a {
-    opacity: 0.7;
-    height: 100%;
-    cursor: pointer;
     color: #333;
+    cursor: pointer;
     display: block;
+    height: 100%;
+    opacity: 0.7;
     text-decoration: none;
 
     i {
-      font-size: $font-size-sm;
       display: inline-block;
+      font-size: $font-size-sm;
       line-height: 33px;
     }
   }
@@ -84,45 +88,48 @@
   }
 
   > li.ccm-inline-toolbar-icon-cell.ccm-inline-toolbar-icon-selected > a {
-    opacity: 1.0;
+    opacity: 1;
   }
 
   > li.ccm-inline-toolbar-icon-cell > a:hover {
-    opacity: 1.0;
+    opacity: 1;
   }
 
   > li.ccm-inline-toolbar-button {
-
-    padding: 0px;
     background: transparent;
+
+    padding: 0;
+
     button {
       background: #f3f3f3;
-      height: 33px;
-      text-align: center;
-      padding: 0px 20px 0px 20px;
+      border: 0;
+      border-radius: 0;
+      color: #333;
       display: inline-block;
       font-size: $font-size-sm;
-      color: #333;
-      border: 0px;
+      height: 33px;
+      padding: 0 20px;
+      text-align: center;
       width: 100%;
-      border-radius: 0;
     }
   }
+
   > li.ccm-inline-toolbar-select {
     select {
-      border: none;
+      background-position: right 5px top 5px;
+      border: 0;
       height: 27px;
       padding: 2px 28px 2px 2px;
-      background-position: right 5px top 5px;
     }
   }
+
   > li.ccm-inline-toolbar-button-cancel button {
     @include gradient-y(#f3f3f3, #eaeaea);
   }
 
   > li.ccm-inline-toolbar-button-cancel button:hover {
-    background-image: none;
     background-color: #fff;
+    background-image: none;
   }
 
   > li.ccm-inline-toolbar-button-save {
@@ -130,44 +137,43 @@
   }
 
   > li.ccm-inline-toolbar-button-save button {
-    background: #09f;
     @include gradient-y(#09f, #0094f6);
+    background: #09f;
     color: #fff;
   }
 
   > li.ccm-inline-toolbar-button-save button:hover {
-    background-image: none;
     background-color: #007cce;
+    background-image: none;
   }
 }
 
 #ccm-inline-toolbar-container {
-  padding: 10px 0px 10px 0px;
-  width: 100%;
+  box-sizing: border-box;
+  left: 0;
+  opacity: 0;
+  padding: 10px 0;
   position: absolute;
   top: 0;
   transition: opacity 0.3s ease-in;
-  opacity: 0;
-  box-sizing: border-box;
-  left: 0;
+  width: 100%;
   z-index: $index-level-inline-toolbar; /* same as toolbar */
 }
 
 #ccm-inline-toolbar-container.ccm-inline-toolbar-affixed {
+  background-color: rgba(0, 0, 0, 0.4);
   position: fixed;
   top: 0 !important;
-  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .ccm-panel-left {
-
   .sp-container {
+    background-color: rgba(0, 0, 0, 0.95);
+    border: 0;
     border-radius: 4px;
-    border: 0px;
-    background-color: rgba(0,0,0,0.95);
 
     .sp-picker-container {
-      border-left: 0px;
+      border-left: 0;
 
       .sp-color,
       .sp-alpha,
@@ -177,7 +183,7 @@
         border-radius: 4px;
 
         .sp-alpha-inner {
-          border: 0px;
+          border: 0;
         }
       }
 
@@ -186,8 +192,8 @@
       }
 
       .sp-alpha {
-        height: 4px;
         background-color: #232323;
+        height: 4px;
       }
 
       .sp-input-container {
@@ -195,66 +201,66 @@
         width: 100%;
 
         .sp-input {
-          color: #8f969a;
-          outline: 0px;
           border: 1px solid #666;
+          color: #8f969a;
+          outline: 0;
 
           &:focus {
             border: 1px solid #666;
             box-shadow: none;
-            outline: 0px;
+            outline: 0;
           }
         }
       }
 
       .sp-alpha-handle {
-        border: none;
-        border-radius: 6px;
-        width: 12px;
-        height: 12px;
-        top: -4px;
-        outline: none !important;
         background-color: #fff;
         background-image: none;
+        border: 0;
+        border-radius: 6px;
+        height: 12px;
+        outline: none !important;
+        top: -4px;
+        width: 12px;
 
       }
 
       a.sp-cancel {
-        float: left;
         color: #8f969a !important;
-        font-weight: bold;
-        font-size: $font-size-sm;
+        float: left;
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: $font-size-sm;
+        font-weight: bold;
         text-transform: capitalize;
 
         &:hover {
-          text-decoration: none;
           color: rgb(235, 54, 54) !important;
+          text-decoration: none;
         }
       }
 
       .sp-button-container {
         display: block;
-        padding-top: 5px;
         float: none;
+        padding-top: 5px;
 
         button.sp-choose {
-          float: right;
-          color: #8f969a !important;
-          font-weight: bold;
-          font-size: $font-size-sm;
-          border: none !important;
-          text-shadow: none !important;
           background-color: transparent !important;
           background-image: none !important;
-          padding: 2px;
-          font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          text-transform: capitalize;
+          border: 0 !important;
           box-shadow: none;
+          color: #8f969a !important;
+          float: right;
+          font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+          font-size: $font-size-sm;
+          font-weight: bold;
+          padding: 2px;
+          text-shadow: none !important;
+          text-transform: capitalize;
 
           &:hover {
-            text-decoration: none;
             color: #0c6 !important;
+            text-decoration: none;
           }
 
           &:focus {
@@ -268,8 +274,8 @@
       }
 
       .sp-initial {
-        overflow: hidden;
         float: none;
+        overflow: hidden;
         width: 100%;
 
         span {
@@ -283,17 +289,22 @@
 
 .ccm-ui {
   div.dropdown-menu.ccm-inline-design-dropdown-menu {
+    background-color: #0f0f0f;
+    color: #7f8d90;
+
+    line-height: $line-height-base;
     min-width: 265px;
+    padding: 20px;
+
+    text-align: left;
 
     &.ccm-inline-design-dropdown-menu-doubled {
       min-width: 522px;
     }
 
-    text-align: left;
-
     .ccm-file-selector {
-      margin-top: 5px;
       margin-bottom: 15px;
+      margin-top: 5px;
     }
 
     .ccm-inline-style-slider-heading {
@@ -304,17 +315,17 @@
     .ccm-inline-style-slider-display-value {
       display: inline-block;
       margin-left: 5%;
-      width: 25%;
       text-align: left;
       vertical-align: text-bottom;
+      width: 25%;
 
-      input[type="text"] {
-        width: 100%;
+      input[type='text'] {
         background: #444;
         color: #ccc;
-        text-align: center;
-        margin-top: 0;
         margin-bottom: 0;
+        margin-top: 0;
+        text-align: center;
+        width: 100%;
 
         &.ccm-slider-value-unit-appended {
           width: 80%;
@@ -324,102 +335,106 @@
     }
 
     .ccm-inline-style-sliders {
+      display: inline-block;
+      margin-bottom: 15px;
+      vertical-align: middle;
+      width: 68%;
+
       &.ui-slider-horizontal {
         margin-bottom: 15px;
       }
-      width: 68%;
-      display: inline-block;
-      vertical-align: middle;
-      margin-bottom: 15px;
     }
+
     a.ui-slider-handle {
       background-color: #888 !important;
       border-radius: 7px;
       cursor: pointer;
+
       &:focus {
-        outline: none;
         background-color: #666;
+        outline: none;
       }
     }
 
     .ui-slider-horizontal {
-      margin-top: 5px;
-      margin-bottom: 5px;
       background: #444;
       border-radius: 4px;
+      margin-bottom: 5px;
+      margin-top: 5px;
     }
 
     button.btn-default {
       @include button-variant(#ccc, #666, #333);
 
+      opacity: 0.5;
+
       &.active {
         opacity: 1;
       }
-
-      opacity: 0.5;
     }
-    padding: 20px;
-    background-color: #0f0f0f;
-    color: #7f8d90;
-    input[type="text"] {
+
+    input[type='text'] {
       border-radius: 3px;
-      padding: 5px 10px;
       font-size: $font-size-sm;
       font-weight: 200;
-      margin-top: 5px;
       margin-bottom: 15px;
+      margin-top: 5px;
+      padding: 5px 10px;
     }
+
     select {
       &.form-control {
-        background: #aaaaaa;
+        background: #aaa;
         color: #4c4c4d;
-        padding-right: 30px;
         margin-bottom: 15px;
         margin-top: 5px;
+        padding-right: 30px;
       }
     }
+
     .ccm-inline-select-container {
       position: relative;
-      &:after {
+
+      &::after {
+        bottom: 10px;
+        color: #707070;
         content: '\f0dd';
         font-family: FontAwesome;
-        color: #707070;
         position: absolute;
-        bottom: 10px;
         right: 15px;
       }
-      #backgroundRepeat {
 
-      }
     }
 
     .sp-dd {
       display: none;
     }
+
     .sp-replacer {
-      padding: 0;
+      border: 1px solid #444;
+      border-radius: 4px;
+      height: 28px;
       margin-left: 10px;
+      padding: 0;
+      width: 28px;
+
       .sp-preview {
-        width: 28px;
-        height: 28px;
         border: 0;
+        height: 28px;
+        width: 28px;
+
         .sp-preview-inner {
-          width: 28px;
           height: 28px;
+          width: 28px;
         }
       }
-      width: 28px;
-      height: 28px;
-      border-radius: 4px;
-      border: 1px solid #444;
     }
 
-    line-height: $line-height-base;
     h3 {
-      font-weight: bold;
-      font-size: $font-size-sm;
       color: #fff;
-      margin: 0px 0px 20px 0px;
+      font-size: $font-size-sm;
+      font-weight: bold;
+      margin: 0 0 20px;
     }
 
     hr {

--- a/assets/cms/scss/_intelligent-search.scss
+++ b/assets/cms/scss/_intelligent-search.scss
@@ -1,18 +1,19 @@
+/* stylelint-disable property-no-vendor-prefix, at-rule-no-vendor-prefix, selector-max-id */
 div#ccm-intelligent-search-results {
-  text-align: left;
-  padding: 0px 0px 0px 40px;
-  z-index: $index-level-intelligent-search;
-  position: fixed;
   background-color: #fff;
-  display: none;
-  top: 48px;
-  right: 120px;
-  width: 251px;
-  border-left: 1px solid #ccc;
-  border-right: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  display: none;
+  padding: 0 0 0 40px;
+  position: fixed;
+  right: 120px;
+  text-align: left;
+  top: 48px;
+  width: 251px;
+  z-index: $index-level-intelligent-search;
 
   span {
     display: none;
@@ -28,28 +29,28 @@ div#ccm-intelligent-search-results {
 
   div.ccm-intelligent-search-results-module {
     margin-top: -1px;
-    position: relative;
     min-height: 60px;
-    padding-top: 20px;
     padding-bottom: 20px;
+    padding-top: 20px;
+    position: relative;
 
     h1 {
-      margin: 0px;
-      padding: 0px;
-      text-align: left;
       border-bottom: 1px solid #e3e4e4;
+      color: #09f;
       font-size: $font-size-sm;
       font-weight: normal;
-      color: #09f;
       line-height: $line-height-sm;
+      margin: 0;
+      padding: 0;
+      text-align: left;
     }
 
     ul {
-      margin-left: 0px;
-      margin-bottom: 0px !important;
       font-size: $font-size-sm;
+      margin-bottom: 0 !important;
+      margin-left: 0;
       margin-top: 3px !important;
-      padding: 0px;
+      padding: 0;
     }
 
     li {
@@ -66,27 +67,28 @@ div#ccm-intelligent-search-results {
     .loader {
       display: block;
       font-size: $font-size-lg;
+      height: 1em;
+      margin: 20px 0;
       position: relative;
       width: 4em;
-      height: 1em;
-      margin: 20px 0px 20px 0px;
     }
 
     .dot {
-      width: 0.4em;
-      height: 0.4em;
-      border-radius: 0.25em;
-      background: #09f;
-      position: absolute;
-      animation-duration: 0.5s;
-      animation-timing-function: ease;
-      animation-iteration-count: infinite;
       -webkit-animation-duration: 0.5s;
-      -webkit-animation-timing-function: ease;
+      animation-duration: 0.5s;
       -webkit-animation-iteration-count: infinite;
+      animation-iteration-count: infinite;
+      -webkit-animation-timing-function: ease;
+      animation-timing-function: ease;
+      background: #09f;
+      border-radius: 0.25em;
+      height: 0.4em;
+      position: absolute;
+      width: 0.4em;
     }
 
-    .dot1, .dot2 {
+    .dot1,
+    .dot2 {
       left: 0;
     }
 
@@ -99,20 +101,19 @@ div#ccm-intelligent-search-results {
     }
 
     .dot1 {
-      animation-name: loader-reveal;
       -webkit-animation-name: loader-reveal;
+      animation-name: loader-reveal;
     }
 
-    .dot2, .dot3 {
-      animation-name: loader-slide;
+    .dot2,
+    .dot3 {
       -webkit-animation-name: loader-slide;
+      animation-name: loader-slide;
     }
 
     .dot4 {
-      animation-name: loader-reveal;
       animation-direction: reverse; /* thx @HugoGiraudel */
-      -webkit-animation-name: loader-reveal;
-      -webkit-animation-direction: reverse; /* thx @HugoGiraudel */
+      animation-name: loader-reveal;
     }
 
   }
@@ -122,10 +123,10 @@ div#ccm-intelligent-search-results {
       a {
         img {
           float: left;
+          height: 16px;
           margin-right: 8px;
           margin-top: 1px;
           width: 16px;
-          height: 16px
         }
       }
     }
@@ -133,16 +134,16 @@ div#ccm-intelligent-search-results {
 
   li {
     a {
-      display: block;
       border-color: transparent;
       color: #888;
-      padding: 1px 15px 1px 15px;
+      display: block;
+      padding: 1px 15px;
       text-decoration: none;
     }
 
     a:hover {
-      text-decoration: none;
       color: #369;
+      text-decoration: none;
     }
 
     a.ccm-intelligent-search-result-selected {
@@ -153,9 +154,10 @@ div#ccm-intelligent-search-results {
 
 @keyframes loader-reveal {
   from {
-    transform: scale(0.001);
     -webkit-transform: scale(0.001);
+    transform: scale(0.001);
   }
+
   to {
     -webkit-transform: scale(1);
   }
@@ -163,25 +165,26 @@ div#ccm-intelligent-search-results {
 
 @keyframes loader-slide {
   to {
-    transform: translateX(1.5em);
     -webkit-transform: translateX(1.5 em);
+    transform: translateX(1.5em);
   }
 }
 
 @-webkit-keyframes loader-reveal {
   from {
-    transform: scale(0.001);
     -webkit-transform: scale(0.001);
+    transform: scale(0.001);
   }
+
   to {
-    transform: scale(1);
     -webkit-transform: scale(1);
+    transform: scale(1);
   }
 }
 
 @-webkit-keyframes loader-slide {
   to {
-    transform: translateX(1.5em);
     -webkit-transform: translateX(1.5em);
+    transform: translateX(1.5em);
   }
 }

--- a/assets/cms/scss/_item-select-list.scss
+++ b/assets/cms/scss/_item-select-list.scss
@@ -1,22 +1,23 @@
 ul.item-select-list {
-  padding: 2px 0px 0px 0px;
-  margin: 0px 0px 15px 0px;
   list-style-type: none !important;
+  margin: 0 0 15px;
+  padding: 2px 0 0;
 }
 
 ul.item-select-list > li {
-  position: relative;
   margin-bottom: 2px;
-  padding-bottom: 2px
+  padding-bottom: 2px;
+  position: relative;
 }
 
-ul.item-select-list > li > a, ul.item-select-list > li > span {
-  color: $body-color;
+ul.item-select-list > li > a,
+ul.item-select-list > li > span {
   background-repeat: no-repeat;
+  border: 1px solid transparent;
+  color: $body-color;
   display: block;
-  padding: 8px 8px 8px 8px;
+  padding: 8px;
   text-decoration: none;
-  border: 1px solid transparent
 }
 
 ul.item-select-list > li > a:hover,
@@ -28,53 +29,56 @@ ul.item-select-list > li > a:focus {
   text-decoration: none;
 }
 
-ul.item-select-list > li > a img, ul.item-select-list li > span img {
-  vertical-align: middle;
-  max-width: 16px;
-  margin-right: 5px;
+ul.item-select-list > li > a img,
+ul.item-select-list li > span img {
   display: Inline-block;
+  margin-right: 5px;
+  max-width: 16px;
+  vertical-align: middle;
 }
 
 ul.item-select-list > li > a i {
-  vertical-align: middle;
-  width: 16px;
-  text-align: center;
+  display: inline-block;
   -webkit-font-smoothing: antialiased;
   margin-right: 5px;
-  display: inline-block
+  text-align: center;
+  vertical-align: middle;
+  width: 16px;
 }
 
 ul.item-select-list i.ccm-item-select-list-sort {
-  position: absolute;
-  top: 10px;
-  right: 10px;
   font-style: normal;
-  margin: 0px;
+  margin: 0;
+  padding-left: 5px;
   padding-left: 5px;
   padding-right: 5px;
-  padding-left: 5px;
   padding-right: 5px;
-  &:after {
-    font-family: FontAwesome;
+  position: absolute;
+  right: 10px;
+  top: 10px;
+
+  &::after {
     content: $fa-var-arrows-alt-v;
+    font-family: FontAwesome;
   }
+
   &:hover {
     cursor: move;
   }
 }
 
 ul.item-select-list > li > div.item-select-list-content {
-  padding: 10px;
   background-color: #efefef;
   margin-top: 2px;
   overflow: hidden;
+  padding: 10px;
 }
 
 [data-section=customize-results] {
   ul.item-select-list {
     li {
-      padding: 8px;
       margin-bottom: 2px;
+      padding: 8px;
 
       &:hover {
         background-color: #e7e7e7;

--- a/assets/cms/scss/_item-selector.scss
+++ b/assets/cms/scss/_item-selector.scss
@@ -2,21 +2,21 @@
  * Page/entity selector
  */
 div.ccm-item-selector {
-  min-height: 40px;
-  border-radius: 2px;
-  color: #ffffff;
   background-color: $blue;
-  text-align: center;
+  border-radius: 2px;
+  color: #fff;
+  min-height: 40px;
   padding: 8px 12px 8px 8px;
-  transition: .3s;
+  text-align: center;
+  transition: 0.3s;
 
-  &:before,
-  &:after {
-    content: "";
+  &::before,
+  &::after {
+    content: '';
     display: table;
   }
 
-  &:after {
+  &::after {
     clear: both;
   }
 
@@ -24,21 +24,21 @@ div.ccm-item-selector {
     background-color: darken($blue, 10%);
   }
 
-  div.ccm-item-selector-item-selected-thumbnail {
-    margin-right: 10px; float: left;
+  div.ccm-item-selector-item-selected-thumbnail { float: left;
+    margin-right: 10px;
 
     img {
-      max-width: 60px;
       max-height: 60px;
+      max-width: 60px;
     }
   }
 
   a {
-    color: #ffffff !important;
+    color: #fff !important;
     display: block;
 
     &:hover {
-      color: #ffffff !important;
+      color: #fff !important;
       text-decoration: none;
     }
   }

--- a/assets/cms/scss/_layouts.scss
+++ b/assets/cms/scss/_layouts.scss
@@ -15,15 +15,14 @@
   }
 
   .ccm-layout-column-highlight {
+    border-collapse: collapse;
     min-height: 80px;
     padding-top: 1px; /* disable margin collapse inner */
-    border-collapse: collapse;
   }
 
 }
 
 #ccm-layouts-edit-mode.ccm-layouts-edit-mode-edit {
-
   .ccm-layout-column-highlight {
     background-color: #fffff2;
     border: 1px solid #02cc67;
@@ -38,14 +37,14 @@
 }
 
 div.ccm-area-layout-control-bar-wrapper {
-  border-radius: 4px 4px 0px 0px;
   background: #4deb4d;
+  border-radius: 4px 4px 0 0;
   height: 6px;
   line-height: 6px;
   margin-bottom: 6px;
-  margin-top: 10px;
   margin-left: -6px;
   margin-right: -6px;
+  margin-top: 10px;
   padding-left: 6px;
   padding-right: 6px;
   position: relative;
@@ -54,24 +53,23 @@ div.ccm-area-layout-control-bar-wrapper {
 
 div.ccm-area-layout-control-bar {
   background: #4deb4d;
+  border: 0;
   border-radius: 0;
   height: 6px;
   line-height: 6px;
-  border: 0px;
 
   .ui-slider-handle {
-    height: 12px;
     background: #b3feb3;
     border: 1px solid #53ba98;
     border-radius: 2px;
     cursor: move;
+    height: 12px;
     width: 12px;
 
   }
 }
 
 div.ccm-menu-item-hover {
-
   > div.ccm-area-layout-control-bar {
     background: #0c6;
   }
@@ -82,11 +80,11 @@ div.ccm-block-edit-layout {
 }
 
 div.ccm-area-layout-control-bar-add {
-  height: 0px;
+  height: 0;
 }
 
 div.ccm-area-layout-control-bar i {
+  left: -2px;
   position: absolute;
   top: -2px;
-  left: -2px;
 }

--- a/assets/cms/scss/_nprogress.scss
+++ b/assets/cms/scss/_nprogress.scss
@@ -1,31 +1,32 @@
+/* stylelint-disable property-no-vendor-prefix, at-rule-no-vendor-prefix */
 /* Make clicks pass-through */
 #nprogress {
   pointer-events: none;
 
   .bar {
     background: #29d;
-
-    position: fixed;
-    z-index: $index-level-nprogress;
-    top: 0;
+    height: 2px;
     left: 0;
 
+    position: fixed;
+    top: 0;
+
     width: 100%;
-    height: 2px;
+    z-index: $index-level-nprogress;
   }
 
   .peg {
-    display: block;
-    position: absolute;
-    right: 0px;
-    width: 100px;
-    height: 100%;
     box-shadow: 0 0 10px #29d, 0 0 5px #29d;
-    opacity: 1.0;
+    display: block;
+    height: 100%;
+    opacity: 1;
+    position: absolute;
+    right: 0;
 
-    -webkit-transform: rotate(3deg) translate(0px, -4px);
-    -ms-transform: rotate(3deg) translate(0px, -4px);
-    transform: rotate(3deg) translate(0px, -4px);
+    -webkit-transform: rotate(3deg) translate(0, -4px);
+    -ms-transform: rotate(3deg) translate(0, -4px);
+    transform: rotate(3deg) translate(0, -4px);
+    width: 100px;
   }
 
   .spinner {
@@ -45,11 +46,11 @@
 }
 
 @-webkit-keyframes nprogress-spinner {
-  0%   { -webkit-transform: rotate(0deg); }
+  0% { -webkit-transform: rotate(0deg); }
   100% { -webkit-transform: rotate(360deg); }
 }
 @keyframes nprogress-spinner {
-  0%   { transform: rotate(0deg); }
+  0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
 

--- a/assets/cms/scss/_page-areas.scss
+++ b/assets/cms/scss/_page-areas.scss
@@ -1,44 +1,47 @@
+/* stylelint-disable value-no-vendor-prefix, function-url-quotes */
 /**
  * Highlighter
  */
 
 div#ccm-menu-click-proxy {
-  opacity: 0;
-  height: 0px;
-  width: 0px;
-  position: absolute;
-  cursor: pointer;
-  z-index: $index-level-in-context-click-proxy;
   background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+  cursor: pointer;
+  height: 0;
+  opacity: 0;
+  position: absolute;
+  width: 0;
+  z-index: $index-level-in-context-click-proxy;
 }
 
 div#ccm-menu-highlighter {
-  z-index: $index-level-in-context-menu-highlighter;
-  height: 0px;
-  width: 0px;
-  position: absolute;
   background-color: transparent;
-  transition: background-color 0.5s cubic-bezier(0.190, 1.000, 0.220, 1.000);
+  height: 0;
+  position: absolute;
+  transition: background-color 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+  width: 0;
+  z-index: $index-level-in-context-menu-highlighter;
 }
 
 /**
  * Blocks AND areas
  */
-div.ccm-block-edit, div.ccm-area, div.ccm-area-disabled {
-  position: relative;
-  opacity: 1;
+div.ccm-block-edit,
+div.ccm-area,
+div.ccm-area-disabled {
   @include clearfix();
+  opacity: 1;
+  position: relative;
 }
 
 /**
  * sorting blocks in page
  */
 div.ccm-block-type-sorting {
+  background-color: rgba(128, 128, 128, 0.1);
   border: 1px solid $gray-700;
-  box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.5);
   overflow: hidden;
   padding: 10px;
-  background-color: rgba(128, 128, 128, 0.1);
   transform: rotate(5 deg);
 }
 
@@ -47,30 +50,32 @@ div.ccm-block-type-sorting {
  */
 
 div.ccm-block-edit {
-  position: relative;
-  opacity: 1;
   @include clearfix();
   min-height: 16px;
-
-  transition: outline-color 0.5 s cubic-bezier(0.190, 1.000, 0.220, 1.000);
+  opacity: 1;
   outline: 1px solid transparent;
   outline-offset: -1px;
+  position: relative;
+
+  transition: outline-color 0.5 s cubic-bezier(0.19, 1, 0.22, 1);
 }
 
-div.ccm-block-edit.ccm-menu-item-hover, div.ccm-block-edit.ccm-block-highlight {
+div.ccm-block-edit.ccm-menu-item-hover,
+div.ccm-block-edit.ccm-block-highlight {
   outline: 1px solid #59ec59;
 
   > div.ccm-custom-style-container > ul.ccm-edit-mode-inline-commands,
   > ul.ccm-edit-mode-inline-commands {
     float: none;
     list-style-type: none;
-    margin: 0px !important;
+    margin: 0 !important;
     opacity: 1;
   }
 }
 
 div.ccm-global-area {
-  div.ccm-block-edit.ccm-menu-item-hover, div.ccm-block-edit.ccm-block-highlight {
+  div.ccm-block-edit.ccm-menu-item-hover,
+  div.ccm-block-edit.ccm-block-highlight {
     outline: 1px solid #80d0ec;
   }
 }
@@ -80,29 +85,28 @@ div.ccm-global-area {
   */
 
 div.ccm-area {
-  /* margin-bottom: 50px; */
-  transition: outline-color 0.5 s cubic-bezier(0.190, 1.000, 0.220, 1.000);
   outline: 1px solid transparent;
   outline-offset: -1px;
+  /* margin-bottom: 50px; */
+  transition: outline-color 0.5 s cubic-bezier(0.19, 1, 0.22, 1);
 
   /**
    * draggable blocks into area
    */
 
   .ccm-area-block-dropzone-active {
-    margin-top: -8px;
     margin-bottom: -8px;
+    margin-top: -8px;
 
     .ccm-area-block-dropzone-inner {
-      height: 10px;
-      margin-top: 2px;
-      margin-bottom: 2px;
       border: 2px solid rgba(0, 0, 0, 0);
+      height: 10px;
+      margin-bottom: 2px;
+      margin-top: 2px;
     }
   }
 
   .ccm-area-block-dropzone-over {
-
     .ccm-area-block-dropzone-inner {
       border: 2px solid #0c6;
     }
@@ -125,33 +129,33 @@ div.ccm-area.ccm-menu-item-hover {
 }
 
 div.ccm-area-footer {
-  opacity: 0;
-  transition: opacity 0.5 s cubic-bezier(0.190, 1.000, 0.220, 1.000);
-  position: absolute;
   //bottom: -35px;
-  left: 0px;
+  left: 0;
+  max-width: 100%;
+  opacity: 0;
+  padding-left: 20px;
+  position: absolute;
+  transition: opacity 0.5 s cubic-bezier(0.19, 1, 0.22, 1);
+  white-space: nowrap;
   //padding-top: 15px;
   z-index: $index-level-in-context-area-handle;
-  padding-left: 20px;
-  white-space: nowrap;
-  max-width: 100%;
 
   div.ccm-area-footer-handle {
-    display: inline-block;
-    border-left: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
-    border-right: 1px solid #ccc;
-    padding: 8px 15px 8px 15px;
-    color: #666;
-    height: 35px;
-    font-size: $font-size-base !important;
     background-color: #f5f5f5;
+    border-bottom: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    color: #666;
+    display: inline-block;
+    font-size: $font-size-base !important;
+    height: 35px;
     max-width: 100%;
+    padding: 8px 15px;
 
     > span {
-      text-overflow: ellipsis;
-      overflow: hidden;
       display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     i {
@@ -176,11 +180,11 @@ div.ccm-menu-item-hover {
 /**
  * Empty areas
  */
-div.ccm-area[data-total-blocks="0"] {
+div.ccm-area[data-total-blocks='0'] {
+  min-height: 50px;
 
   outline: 1px solid #e6e6e6;
   outline-offset: -1px;
-  min-height: 50px;
 
 }
 
@@ -188,18 +192,20 @@ div.ccm-area[data-total-blocks="0"] {
  * Empty areas - firefox stupidity
  */
 @-moz-document url-prefix() {
-  div.ccm-area[data-total-blocks="0"] {
+  div.ccm-area[data-total-blocks='0'] {
     border: 1px solid #e6e6e6;
     outline: none !important;
   }
 }
 
-div.ccm-area[data-total-blocks="0"].ccm-area-drag-block-type-over, div.ccm-area[data-total-blocks="0"].ccm-menu-item-hover {
+div.ccm-area[data-total-blocks='0'].ccm-area-drag-block-type-over,
+div.ccm-area[data-total-blocks='0'].ccm-menu-item-hover {
 
   outline: 1px solid #0c6;
 
   div.ccm-area-footer-handle {
     border-color: #0c6;
+
     span {
       opacity: 1 !important;
     }
@@ -207,6 +213,7 @@ div.ccm-area[data-total-blocks="0"].ccm-area-drag-block-type-over, div.ccm-area[
 
   &.ccm-global-area {
     outline-color: #80d0ec;
+
     div.ccm-area-footer-handle {
       border-color: #80d0ec;
 
@@ -223,10 +230,9 @@ div.ccm-area.ccm-area-highlight {
   outline-offset: -1px;
 
   > div.ccm-area-footer {
-
     div.ccm-area-footer-handle {
-      border-left: 1px solid #59ec59;
       border-bottom: 1px solid #59ec59;
+      border-left: 1px solid #59ec59;
       border-right: 1px solid #59ec59;
       color: #000;
     }
@@ -236,10 +242,9 @@ div.ccm-area.ccm-area-highlight {
     outline: 1px solid #80d0ec;
 
     > div.ccm-area-footer {
-
       div.ccm-area-footer-handle {
-        border-left: 1px solid #80d0ec;
         border-bottom: 1px solid #80d0ec;
+        border-left: 1px solid #80d0ec;
         border-right: 1px solid #80d0ec;
         color: #000;
       }
@@ -247,8 +252,9 @@ div.ccm-area.ccm-area-highlight {
   }
 }
 
-div.ccm-area[data-total-blocks="0"].ccm-area-highlight {
+div.ccm-area[data-total-blocks='0'].ccm-area-highlight {
   outline: 1px solid #59ec59;
+
   &.ccm-global-area-highlight {
     outline-color: #80d0ec;
   }
@@ -268,6 +274,7 @@ div#ccm-menu-highlighter.ccm-area-highlight {
  */
 div.ccm-area.ccm-area-inline-edit-disabled {
   outline-color: transparent;
+
   div.ccm-area-footer {
     display: none;
   }
@@ -281,9 +288,9 @@ div.ccm-area.ccm-area-inline-edit-disabled {
   }
 
   div.ccm-block-edit-inline-active {
+    opacity: 1;
     outline: 1px solid #5eed5e;
     outline-offset: -1px;
-    opacity: 1;
   }
 
 }
@@ -296,8 +303,8 @@ div#ccm-menu-highlighter.ccm-block-highlight {
   opacity: 0.4;
 
   &.ccm-global-area-block-highlight {
-    outline: 1px solid #80d0ec;
     background-color: rgb(128, 208, 236);
+    outline: 1px solid #80d0ec;
   }
 }
 
@@ -305,41 +312,41 @@ div#ccm-menu-highlighter.ccm-block-highlight {
  * Inline commands
  */
 ul.ccm-edit-mode-inline-commands {
-  list-style-type: none;
-  opacity: 0;
-  position: absolute;
-  padding: 0px !important;
-  margin: 0px !important;
-  top: 1px;
-  right: 1px;
-  height: 20px !important;
   background-color: #fff;
+  height: 20px !important;
+  list-style-type: none;
+  margin: 0 !important;
+  opacity: 0;
+  padding: 0 !important;
+  position: absolute;
+  right: 1px;
+  top: 1px;
   z-index: $index-level-inline-commands; // has to be over the click proxy
   li {
     display: inline-block;
-    line-height: 20px !important;
     height: 20px !important;
-    padding: 0px !important;
-    margin: 0px !important;
+    line-height: 20px !important;
+    margin: 0 !important;
+    padding: 0 !important;
 
     a {
-      position: relative;
       color: #555 !important;
       display: inline-block;
       font-weight: lighter;
-      width: 20px !important;
       height: 20px !important;
       line-height: 20px !important;
+      position: relative;
       text-align: center;
+      width: 20px !important;
       
       @include hover {
         color: #000 !important;
       }
       
       i {
+        left: 3px;
         position: absolute;
         top: 3px;
-        left: 3px;
         vertical-align: middle;
       }
       
@@ -364,17 +371,20 @@ ul.ccm-edit-mode-inline-commands:hover {
  * In page menus
  */
 #ccm-popover-menu-container div.popover {
-
   &.ccm-popover-inverse {
     background-color: rgba(0, 0, 0, 0.6) !important;
+
     ul.dropdown-menu {
       background-color: rgba(0, 0, 0, 0.6) !important;
+
       li {
         span {
           color: #444245;
         }
+
         a {
           color: #7f7f81;
+
           &:hover {
             color: #c5c5c7 !important;
           }
@@ -388,14 +398,14 @@ ul.ccm-edit-mode-inline-commands:hover {
   }
 
   ul.dropdown-menu {
+    border: 0;
+    box-shadow: none !important;
+    display: block;
+    float: none !important;
+    margin: 0 !important;
+    padding: 0;
 
     position: static;
-    display: block;
-    margin: 0px !important;
-    float: none !important;
-    padding: 0px;
-    border: 0px;
-    box-shadow: none !important;
 
     li:last-child a {
       border-bottom-left-radius: 4px;
@@ -411,21 +421,23 @@ ul.ccm-edit-mode-inline-commands:hover {
 
       display: block;
 
-      a, span {
-        text-decoration: none !important;
-        padding: 3px 12px !important;
-        color: #999;
-        display: block;
-      }
-      a:hover {
-        color: #000;
-        background-image: none !important;
-        background-color: transparent !important;
-      }
-
       font-family: $font-family-base !important;
       font-size: $font-size-base !important;
       line-height: $line-height-base !important;
+
+      a,
+      span {
+        color: #999;
+        display: block;
+        padding: 3px 12px !important;
+        text-decoration: none !important;
+      }
+
+      a:hover {
+        background-color: transparent !important;
+        background-image: none !important;
+        color: #000;
+      }
 
     }
 
@@ -445,17 +457,18 @@ ul.ccm-edit-mode-inline-commands:hover {
  * Edit mode drag areas - The green hover state things
  */
 div.ccm-area-drag-area {
-  transition: outline-width 0.5s cubic-bezier(0.190, 1.000, 0.220, 1.000), outline-color 0.5s cubic-bezier(0.190, 1.000, 0.220, 1.000);
-  outline-width: 0;
-  outline-style: solid;
-  text-indent: -10000em;
   line-height: 0px;
   outline-color: rgb(170, 255, 170);
+  outline-style: solid;
+  outline-width: 0;
+  text-indent: -10000em;
+  transition: outline-width 0.5s cubic-bezier(0.19, 1, 0.22, 1), outline-color 0.5s cubic-bezier(0.19, 1, 0.22, 1);
 
   &.ccm-area-drag-area-contender {
     background-color: rgba(221, 255, 221, 0.5);
-    outline: solid 5px rgba(221, 255, 221, .7) !important;
+    outline: solid 5px rgba(221, 255, 221, 0.7) !important;
   }
+
   &.ccm-area-drag-area-selectable {
     outline-width: 10px !important;
   }
@@ -471,7 +484,8 @@ div.ccm-global-area {
   }
 }
 
-html.ccm-panel-add-block, html.ccm-block-dragging {
+html.ccm-panel-add-block,
+html.ccm-block-dragging {
   div.ccm-area-drag-area {
     outline-width: 2px;
   }
@@ -480,25 +494,26 @@ html.ccm-panel-add-block, html.ccm-block-dragging {
 /**
  * Empty areas
  */
-div.ccm-area[data-total-blocks="0"] {
+div.ccm-area[data-total-blocks='0'] {
   div.ccm-area-drag-area {
-    text-indent: 0;
-    text-align: center;
-    padding: 24px;
     color: #bbb;
+    padding: 24px;
+    text-align: center;
+    text-indent: 0;
   }
 }
 
-a.ccm-block-edit-drag, a.ccm-panel-add-block-draggable-block-type-dragger {
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  width: 90px;
-  height: 90px;
-  z-index: 1000000;
+a.ccm-block-edit-drag,
+a.ccm-panel-add-block-draggable-block-type-dragger {
   cursor: -moz-grab;
   cursor: -webkit-grab;
   cursor: grab;
+  height: 90px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 90px;
+  z-index: 1000000;
 
   &.pep-active {
     cursor: -moz-grabbing;
@@ -520,23 +535,23 @@ body {
  * Disabled edit mode blocks
  */
 div.ccm-edit-mode-disabled-item {
-  border: 1px solid #dadada;
   background-color: #f1f1f1;
-  text-align: center;
-  padding: 10px;
+  border: 1px solid #dadada;
   color: #666;
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
   font-weight: 200;
+  padding: 10px;
+  text-align: center;
 }
 
 div.ccm-block-edit {
   > div.ccm-block-cover {
+    height: 100%;
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     width: 100%;
-    height: 100%;
   }
 }
 

--- a/assets/cms/scss/_panels.scss
+++ b/assets/cms/scss/_panels.scss
@@ -1,2 +1,2 @@
-@import "panels/shared";
-@import "panels/sitemap";
+@import 'panels/shared';
+@import 'panels/sitemap';

--- a/assets/cms/scss/_permission-grid.scss
+++ b/assets/cms/scss/_permission-grid.scss
@@ -1,17 +1,17 @@
 table.ccm-permission-grid {
-  border: 0px;
+  border: 0;
 }
 
 table.ccm-permission-grid td.ccm-permission-grid-name {
   text-align: right;
-  width: auto;
   white-space: nowrap;
+  width: auto;
 }
 
 table.ccm-permission-grid td {
+  border-left: 0 !important;
+  border-right: 0 !important;
   width: 100%;
-  border-left: 0px !important;
-  border-right: 0px !important;
 }
 
 div.ccm-permission-access-line {
@@ -23,5 +23,5 @@ div.ccm-permission-access-line {
 }
 
 td.ccm-permissions-grid-cell-active {
-  background-color: #e4f4f8
+  background-color: #e4f4f8;
 }

--- a/assets/cms/scss/_search-v8.scss
+++ b/assets/cms/scss/_search-v8.scss
@@ -19,8 +19,8 @@ div.ccm-header-search-form-input {
 
   a.ccm-header-launch-advanced-search +
   input.form-control {
-    width: 312px;
     padding-right: 110px;
+    width: 312px;
   }
 
   a.ccm-header-reset-search,
@@ -32,9 +32,10 @@ div.ccm-header-search-form-input {
 
   a.ccm-header-reset-search {
     left: 10px;
+
     &.ccm-header-reset-search-right {
-      right: 10px;
       left: auto;
+      right: 10px;
 
     }
   }
@@ -45,42 +46,49 @@ form.form-inline div.ccm-header-search-form-input {
 }
 
 ul.ccm-header-search-navigation {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0 0;
+  text-align: right;
+
   li {
     display: inline-block;
     margin-left: 20px;
   }
-  list-style: none;
-  text-align: right;
-  padding: 4px 0px 0px 0px;
-  margin: 0px 0px 0px 0px;
+
   a {
     color: #777;
     transition: 0.1s linear all;
   }
-  a:focus, a:hover {
-    text-decoration: none;
+
+  a:focus,
+  a:hover {
     color: #333;
     outline: none;
+    text-decoration: none;
   }
+
   a.link-primary {
     color: #09f;
   }
+
   a#ccm-file-manager-upload {
+
+    color: #09f;
 
     position: relative;
 
     input[type=file] {
-      position: absolute;
-      opacity: 0;
-      top:  0px;
-      left: 0px;
-      width: 100%;
-      height: 20px;
       border: 1px solid black;
       cursor: pointer;
+      height: 20px;
+      left: 0;
+      opacity: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
     }
 
-    color: #09f;
     &:hover {
       color: #2b507b;
     }
@@ -88,22 +96,25 @@ ul.ccm-header-search-navigation {
 }
 
 div.ui-dialog {
-
   div.table-responsive {
-    margin: -15px -26px -20px -26px;
+    margin: -15px -26px -20px;
   }
+
   div.ccm-search-results-breadcrumb {
     display: inline-block;
-    position: absolute;
     height: 15px;
-    top: 10px;
     left: 10px;
+    position: absolute;
+    top: 10px;
     z-index: 2;
+
     ol {
-      margin-bottom: 0px;
-      li a, li span {
-        position: static;
+      margin-bottom: 0;
+
+      li a,
+      li span {
         font-weight: normal;
+        position: static;
       }
     }
   }
@@ -135,19 +146,21 @@ div.ccm-search-results-breadcrumb {
 
   ol.breadcrumb {
     background-color: transparent;
-    padding: 0px;
-    position: relative;
     margin-bottom: -20px;
+    padding: 0;
+    position: relative;
 
     > li a {
       color: #777;
       transition: 0.1s linear all;
     }
+
     > li > a {
-      &:hover, &:focus {
-        text-decoration: none;
+      &:hover,
+      &:focus {
         color: #333;
         outline: none;
+        text-decoration: none;
       }
     }
 
@@ -160,16 +173,16 @@ div.ccm-search-results-breadcrumb {
       color: #09f;
     }
 
-    > li + li:before {
-      content: ">";
-      font-size: $font-size-sm;
+    > li + li::before {
       color: #999;
+      content: '>';
+      font-size: $font-size-sm;
       font-style: normal;
-      text-decoration: inherit;
-      position: relative;
-      top: -2px;
+      left: 0;
       padding-right: 8px;
-      left: 0px;
+      position: relative;
+      text-decoration: inherit;
+      top: -2px;
     }
   }
 
@@ -182,45 +195,45 @@ div.ccm-draggable-search-item {
 
   position: relative;
 
-  &:after {
-    font-family: FontAwesome;
-    font-style: normal;
-    text-decoration: inherit;
-    font-size: $font-size-lg;
+  &::after {
     color: #666;
     display: inline-block;
+    font-family: FontAwesome;
+    font-size: $font-size-lg;
+    font-style: normal;
+    text-decoration: inherit;
   }
 
   &.ccm-search-results-stack {
-    &:after {
-      content: "\f1b3";
+    &::after {
+      content: '\f1b3';
     }
   }
 
   &.ccm-search-results-folder {
-    &:after {
-      content: "\f07b";
+    &::after {
+      content: '\f07b';
     }
   }
 
   &.ccm-search-results-file {
-    &:after {
-      content: "\f016";
+    &::after {
+      content: '\f016';
     }
   }
 
   span {
-    display: inline-block;
-    background-color: #0099ff;
-    color: #fff;
-    width: 20px;
-    height: 20px;
-    text-align: center;
-    font-weight: bold;
+    background-color: #09f;
     border-radius: 10px;
-    top: -2px;
-    right: 18px;
+    color: #fff;
+    display: inline-block;
+    font-weight: bold;
+    height: 20px;
     position: absolute;
+    right: 18px;
+    text-align: center;
+    top: -2px;
+    width: 20px;
 
   }
 }

--- a/assets/cms/scss/_search.scss
+++ b/assets/cms/scss/_search.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable property-no-vendor-prefix, function-url-quotes */
 /*
  * Search Fields, including action select menu, keyword search bar, advanced search
  */
@@ -6,26 +7,26 @@
 
   // search field selector
   select.ccm-search-bulk-action {
-    border: 0px;
-    box-shadow: none !important;
     -webkit-appearance: none;
-    padding: 0px;
-    margin: 0px;
-    color: #999;
-    height: auto;
-    width: 200px;
-    height: 34px;
-    vertical-align: top;
-    display: inline-block;
-    outline: none !important;
-    border-radius: 0px;
-    padding-right: 15px;
     background: transparent url(../../images/icons/arrow_down.png) no-repeat center right;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none !important;
+    color: #999;
+    display: inline-block;
+    height: auto;
+    height: 34px;
+    margin: 0;
+    outline: none !important;
+    padding: 0;
+    padding-right: 15px;
+    vertical-align: top;
+    width: 200px;
   }
 
   div.ccm-search-field-selector {
     div.ccm-search-field-selector-row {
-      padding-left: 0px;
+      padding-left: 0;
 
       &:first-of-type {
         margin-top: -10px;
@@ -33,10 +34,10 @@
 
       a.ccm-search-remove-field {
         color: #aaa;
+        padding: 8px;
         position: absolute;
         right: -4px;
         top: -2px;
-        padding: 8px;
 
         &:hover {
           color: #666;
@@ -47,9 +48,9 @@
   }
 
   div.ccm-search-field-selector-row {
-    min-height: 34px;
     margin-bottom: 10px;
-    padding: 0px 0px 10px 0px;
+    min-height: 34px;
+    padding: 0 0 10px;
     position: relative;
     
     @include media-breakpoint-up(sm) {
@@ -58,59 +59,71 @@
 
     div.form-group {
 
+      margin-bottom: 0;
+
       label.control-label {
-        width: 200px;
         color: #999;
-        line-height: 34px;
-        vertical-align: top;
-        margin-right: 40px;
-        margin-bottom: 0px;
         font-size: $font-size-base !important;
         font-weight: normal;
+        line-height: 34px;
+        margin-bottom: 0;
+        margin-right: 40px;
+        vertical-align: top;
+        width: 200px;
       }
-
-      margin-bottom: 0px;
 
     }
 
     div.ccm-search-field-content {
-      padding-left: 10px;
       display: inline-block;
+      padding-left: 10px;
+
       div.ccm-search-main-lookup-field {
-        border-left: 0px;
+        border-left: 0;
       }
     }
 
   }
 
   form.ccm-search-fields {
-    position: relative;
+    padding-bottom: 0; /* the ccm-search-fields-row has a margin on the bottom */
     padding-top: 10px;
-    padding-bottom: 0px; /* the ccm-search-fields-row has a margin on the bottom */
+    position: relative;
 
     div.ccm-search-main-lookup-field {
       position: relative;
 
       i {
+        left: 5px;
         position: absolute;
         top: 8px;
-        left: 5px;
       }
 
       input {
-        border: 0px;
-        color: #3784d6;
-        font-weight: 200;
-        font-size: $font-size-lg;
-        outline: none !important;
-        border-radius: 0px;
+        border: 0;
+        border-radius: 0;
         box-shadow: none;
+        color: #3784d6;
+        font-size: $font-size-lg;
+        font-weight: 200;
         margin-left: 30px;
+        outline: none !important;
         width: calc(100% - 30px);
       }
     }
 
     ul.ccm-search-form-advanced {
+
+      font-size: $font-size-sm;
+
+      position: absolute;
+      right: 18px;
+      top: -20px;
+
+      @include media-breakpoint-up(md) {
+        right: 48px;
+      }
+
       a {
         color: #afafaf;
 
@@ -123,26 +136,16 @@
       li {
         margin-left: 20px;
       }
-
-      position: absolute;
-      right: 18px;
-      top: -20px;
-
-      @include media-breakpoint-up(md) {
-        right: 48px;
-      }
-
-      font-size: $font-size-sm;
     }
 
     button.ccm-search-field-hidden-submit {
       border: 0 none;
       height: 0;
-      position: absolute;
-      width: 0;
-      padding: 0;
       margin: 0;
       overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 0;
     }
   }
 
@@ -160,8 +163,8 @@ div.ccm-search-field-content {
 
   // Logs level selectize input override
   .selectize-control.form-control {
-    border: none;
-    padding: 0px;
+    border: 0;
+    padding: 0;
   }
 
 }
@@ -273,11 +276,11 @@ table.ccm-search-results-table-icon {
 */
 
 table.ccm-search-results-table {
-
-  width: 100%;
+  -webkit-font-smoothing: antialiased;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -webkit-font-smoothing: antialiased;
+
+  width: 100%;
 
   &.selectable {
     user-select: auto;
@@ -285,26 +288,29 @@ table.ccm-search-results-table {
 
   span.ccm-search-results-checkbox {
     display: block;
+    padding-bottom: 0;
+    padding-top: 0;
     text-align: right;
-    padding-top: 0px;
-    padding-bottom: 0px;
     white-space: nowrap;
 
 
     select.ccm-search-bulk-action {
       display: inline-block;
-      width: auto;
       margin-right: 10px;
-      padding-top: 2px !important;
       padding-bottom: 2px !important;
       padding-left: 10px;
       padding-right: 30px;
+      padding-top: 2px !important;
+      width: auto;
     }
   }
 
   thead {
-
     th {
+
+      background-color: #e7e7e7;
+      color: #999;
+      font-weight: normal;
 
       &:first-child {
         @include media-breakpoint-only(sm) {
@@ -312,62 +318,60 @@ table.ccm-search-results-table {
         }
       }
 
-      input[type=checkbox], input[type=radio] {
-        vertical-align: middle;
+      input[type=checkbox],
+      input[type=radio] {
         border-color: #ccc;
+        vertical-align: middle;
       }
 
       span.ccm-search-results-checkbox {
         input {
-          margin-top: 0px;
+          margin-top: 0;
         }
       }
-
-      background-color: #e7e7e7;
-      color: #999;
-      font-weight: normal;
 
       &.ccm-results-list-active-sort-desc a,
       &.ccm-results-list-active-sort-asc a {
-        color: #333;
         background: #e7e7e7;
+        color: #333;
         white-space: nowrap;
-        &:after {
-          vertical-align: middle;
-          content: "";
-          width: 0;
-          height: 0;
+
+        &::after {
+          content: '';
           display: inline-block;
+          height: 0;
           margin-left: 10px;
+          vertical-align: middle;
+          width: 0;
         }
       }
 
-      &.ccm-results-list-active-sort-desc a:after {
-        content: "\f078";
-        font-family: FontAwesome;
-        font-style: normal;
-        text-decoration: inherit;
-        font-size: $font-size-base / 2;
+      &.ccm-results-list-active-sort-desc a::after {
+        content: '\f078';
         display: inline-block;
-        position: relative;
-        top: -6px;
+        font-family: FontAwesome;
+        font-size: $font-size-base / 2;
+        font-style: normal;
         left: 10px;
-        padding-right: 10px;
         margin-right: 10px;
+        padding-right: 10px;
+        position: relative;
+        text-decoration: inherit;
+        top: -6px;
       }
 
-      &.ccm-results-list-active-sort-asc a:after {
-        content: "\f077";
-        font-family: FontAwesome;
-        font-style: normal;
-        text-decoration: inherit;
-        font-size: $font-size-base / 2;
+      &.ccm-results-list-active-sort-asc a::after {
+        content: '\f077';
         display: inline-block;
-        position: relative;
-        top: -6px;
+        font-family: FontAwesome;
+        font-size: $font-size-base / 2;
+        font-style: normal;
         left: 10px;
-        padding-right: 10px;
         margin-right: 10px;
+        padding-right: 10px;
+        position: relative;
+        text-decoration: inherit;
+        top: -6px;
       }
 
       &:last-child a,
@@ -379,15 +383,16 @@ table.ccm-search-results-table {
         color: #999;
         display: block;
 
-        &:active, &:focus {
-          outline: 0px !important;
+        &:active,
+        &:focus {
+          color: #999;
+          outline: 0 !important;
           text-decoration: none;
-          color:  #999;
         }
 
         &:hover {
-          text-decoration: none;
           color: #333;
+          text-decoration: none;
         }
       }
 
@@ -396,9 +401,10 @@ table.ccm-search-results-table {
         text-align: right;
       }
 
-      a, span {
-        padding: 15px 0px 15px 15px;
+      a,
+      span {
         display: block;
+        padding: 15px 0 15px 15px;
         /* not sure why this was here, it was causing columns to not go the whole width in the sort row
           display: inline-block;
           */
@@ -407,46 +413,50 @@ table.ccm-search-results-table {
       button.btn-menu-launcher {
         background-color: transparent;
         border: 1px solid #aaa;
+
         i {
           color: #aaa;
         }
-        &:active, &:focus {
-          outline: 0px !important;
+
+        &:active,
+        &:focus {
+          outline: 0 !important;
         }
       }
 
       button.btn-menu-launcher[disabled] {
+        border: 1px solid #ccc;
+
         i {
           color: #ccc;
         }
-        border: 1px solid #ccc;
       }
 
     }
   }
 
   tbody {
-
     td {
+      background-color: #fff;
+      border-bottom: 1px solid #dbdbdb;
+
+      color: #999;
+
+      padding: 15px 0 15px 15px;
+
+      transition: all 0.1s;
 
       &:first-child {
         @include media-breakpoint-only(sm) {
           padding-left: 97px;
         }
       }
-      border-bottom: 1px solid #dbdbdb;
 
-      transition: all 0.1s;
-
-      input[type=checkbox], input[type=radio] {
+      input[type=checkbox],
+      input[type=radio] {
         position: relative;
         z-index: $index-level-search-results-checkboxes;
       }
-
-      padding: 15px 0px 15px 15px;
-
-      color: #999;
-      background-color: #fff;
 
       &.ccm-search-results-name {
         width: 300px;
@@ -455,15 +465,14 @@ table.ccm-search-results-table {
     }
 
     td.ccm-search-results-icon {
-      width: 16px;
       text-align: right;
+      width: 16px;
     }
 
     td.ccm-search-results-menu-launcher {
-
       a {
-        transition: all 0.1s;
         color: #999;
+        transition: all 0.1s;
       }
 
 
@@ -486,24 +495,24 @@ table.ccm-search-results-table {
     tr.ccm-parent-menu-item-active,
     tr.ccm-search-select-selected {
       td {
-        cursor: pointer;
-        background-color: rgba(222, 235, 241, 1.0);
+        background-color: rgba(222, 235, 241, 1);
         color: #000;
+        cursor: pointer;
       }
     }
 
     tr.ccm-search-select-hover,
     tr.ccm-parent-menu-item-hover {
       td {
-        cursor: pointer;
         background-color: #edf7fe !important;
         color: #000;
+        cursor: pointer;
       }
     }
 
     tr.ccm-search-select-active-droppable {
       td {
-        background-color: rgba(222, 235, 241, 1.0);
+        background-color: rgba(222, 235, 241, 1);
         color: #000;
       }
     }
@@ -513,6 +522,7 @@ table.ccm-search-results-table {
         color: #333;
         font-weight: bold;
       }
+
       td.ccm-search-results-icon {
         color: #333;
       }
@@ -527,6 +537,7 @@ table.ccm-search-results-table {
           padding-left: 0;
         }
       }
+
       td {
         &:first-child {
           padding-left: 15px;

--- a/assets/cms/scss/_sitemap.scss
+++ b/assets/cms/scss/_sitemap.scss
@@ -1,11 +1,13 @@
 div.ccm-sitemap-tree {
-  .icon-home, .icon-folder, .icon-page {
-    width: 20px;
-    height: 20px;
-    background-size: contain;
-    margin: 12px 5px;
+  .icon-home,
+  .icon-folder,
+  .icon-page {
     background-repeat: no-repeat;
     background-size: contain;
+    background-size: contain;
+    height: 20px;
+    margin: 12px 5px;
+    width: 20px;
   }
 
   .icon-home {
@@ -23,16 +25,19 @@ div.ccm-sitemap-tree {
   .fancytree-expander {
     margin: 10px 8px;
 
-    &.fa-angle-right, &.fa-caret-down, &.fa-caret-right {
-      width: 18px;
-      height: 18px;
-      background-size: contain;
-      margin: 12px 8px 12px 2px;
+    &.fa-angle-right,
+    &.fa-caret-down,
+    &.fa-caret-right {
       background-repeat: no-repeat;
       background-size: contain;
+      background-size: contain;
+      height: 18px;
+      margin: 12px 8px 12px 2px;
+      width: 18px;
     }
 
-    &.fa-angle-right, &.fa-caret-right {
+    &.fa-angle-right,
+    &.fa-caret-right {
       background-image: url($sitemap-expand-icon-b64);
 
       &::before {
@@ -55,12 +60,12 @@ div.ccm-sitemap-tree {
     li {
       span.fancytree-node {
         span.fancytree-title {
+          color: #6f737b;
           font-size: 16px;
-          color: #6F737B;
           letter-spacing: 0;
+          line-height: normal;
           margin: 8px 0;
           padding: 5px;
-          line-height: normal;
         }
       }
     }
@@ -69,12 +74,12 @@ div.ccm-sitemap-tree {
   .fancytree-active {
     span.fancytree-title {
       background-color: #e1e1e1 !important;
-      color: #6F737B !important;
+      color: #6f737b !important;
     }
   }
 
   .fancytree-container {
-    border:none;
+    border: 'none';
   }
 }
 
@@ -82,11 +87,10 @@ div.ccm-sitemap-tree-selector-wrapper {
   margin-bottom: 1em;
 
   div.ccm-sitemap-tree-selector-option {
-
     img {
-      vertical-align: middle;
       display: inline-block;
       margin-right: 10px;
+      vertical-align: middle;
     }
 
   }

--- a/assets/cms/scss/_style-customizer.scss
+++ b/assets/cms/scss/_style-customizer.scss
@@ -1,85 +1,86 @@
 div.ccm-style-customizer-palette {
+  background-color: #020202;
 
-    &.ccm-style-customizer-palette-large {
-        width: 550px;
+  border: 1px solid black;
+  border-radius: 4px;
+  color: #7f8d90;
+  display: none;
+  left: 0;
+  padding: 10px;
+  position: absolute;
+  top: 0;
+  width: 250px;
+  z-index: $index-level-panel-select-widget;
 
-        div.ccm-style-customizer-slider {
-            width: 440px;
-        }
-    }
-
-    border: 1px solid black;
-    width: 250px;
-    padding: 10px;
-    z-index: $index-level-panel-select-widget;
-    display: none;
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    background-color: #020202;
-    border-radius: 4px;
-    color: #7f8d90;
-
-    > div {
-        position: relative;
-        padding-bottom: 12px;
-    }
-
-    > div.checkbox {
-        padding-bottom: 4px;
-    }
-
-    select {
-        display: block;
-        text-align: center;
-        width: 180px;
-        background-color: #aaa;
-        appearance: none;
-        -webkit-appearance: none;
-        padding: 10px;
-        color: #000;
-    }
+  &.ccm-style-customizer-palette-large {
+    width: 550px;
 
     div.ccm-style-customizer-slider {
-        width: 180px;
+      width: 440px;
     }
+  }
 
-    div.ui-slider {
-        background-image: none;
-        background-color: #444;
-        border-color: #444;
-        border-radius: 4px;
+  > div {
+    padding-bottom: 12px;
+    position: relative;
+  }
 
-        a.ui-slider-handle {
-            border: none;
-            border-radius: 7px;
-            background-color: #888 !important;
-            outline: none !important;
-            background-image: none;
-        }
+  > div.checkbox {
+    padding-bottom: 4px;
+  }
+
+  select {
+    appearance: none;
+    background-color: #aaa;
+    color: #000;
+    display: block;
+    padding: 10px;
+    text-align: center;
+    width: 180px;
+  }
+
+  div.ccm-style-customizer-slider {
+    width: 180px;
+  }
+
+  div.ui-slider {
+    background-color: #444;
+    background-image: none;
+    border-color: #444;
+    border-radius: 4px;
+
+    a.ui-slider-handle {
+      background-color: #888 !important;
+      background-image: none;
+      border: 'none';
+      border-radius: 7px;
+      outline: none !important;
     }
+  }
 
-    span.ccm-style-customizer-slider-value {
-        position: absolute;
-        top: 20px;
-        right: 0px;
-    }
+  span.ccm-style-customizer-slider-value {
+    position: absolute;
+    right: 0;
+    top: 20px;
+  }
 
-    div.sp-replacer {
-        top: 8px;
-        right: 5px;
-    }
+  div.sp-replacer {
+    right: 5px;
+    top: 8px;
+  }
 
-    input[type=checkbox], input[type=radio] {
-        border: 1px solid #444;
-    }
+  input[type=checkbox],
+  input[type=radio] {
+    border: 1px solid #444;
+  }
 
-    input[type=checkbox]:checked:after, input[type=radio]:checked:after {
-        color: #3baaf7;
-    }
+  input[type=checkbox]:checked::after,
+  input[type=radio]:checked::after {
+    color: #3baaf7;
+  }
 
-    div.ccm-style-customizer-palette-actions {
-        text-align: center;
-        padding: 8px 0px 8px 0px;
-    }
+  div.ccm-style-customizer-palette-actions {
+    padding: 8px 0;
+    text-align: center;
+  }
 }

--- a/assets/cms/scss/_tabs.scss
+++ b/assets/cms/scss/_tabs.scss
@@ -1,21 +1,21 @@
 div.ccm-ui {
   .nav-tabs {
-
     .nav-link {
-      padding-top: 0;
-      color: $nav-tabs-link-color;
       border-bottom-width: 2px;
-      transition: border-color .25s ease-in-out;
+      color: $nav-tabs-link-color;
+      padding-top: 0;
+      transition: border-color 0.25s ease-in-out;
 
       &:hover {
         color: $gray-500;
       }
 
       &.active {
+        font-weight: bold;
+
         &:hover {
           color: $nav-tabs-link-active-color;
         }
-        font-weight: bold;
       }
 
     }

--- a/assets/cms/scss/_toolbar.scss
+++ b/assets/cms/scss/_toolbar.scss
@@ -1,14 +1,14 @@
-
+/* stylelint-disable selector-max-compound-selectors, property-no-vendor-prefix, selector-max-id */
 div#ccm-toolbar {
+  background: #fafafe;
 
   background-color: $gray-100;
-  background: #FAFAFE;
+  border-bottom: 1px solid #d8d8d8;
+  height: 48px;
+  left: 0;
   position: fixed;
   top: 0;
-  left: 0;
-  height: 48px;
   width: 100%;
-  border-bottom: 1px solid #d8d8d8;
   z-index: $index-level-main-bar; /* over the top of the highlighter, which is 1000 */
 
   &.ccm-toolbar-tour-guide {
@@ -24,13 +24,17 @@ div#ccm-toolbar {
     .ccm-toolbar-accessibility-title {
       display: inline-block;
     }
+
     li > a {
-      width: auto !important;
       padding: 14px 16px;
+      width: auto !important;
     }
-    li > a i, li > a img {
+
+    li > a i,
+    li > a img {
       position: static;
     }
+
     .spinner {
       left: 11px;
     }
@@ -45,56 +49,59 @@ div#ccm-toolbar {
 
   > ul {
     @include clearfix();
-    padding-left: 0px;
     list-style-type: none;
-    margin: 0px;
+    margin: 0;
+    padding-left: 0;
 
     > li {
 
       position: relative;
 
       > a {
+        border-left: 1px solid #d8d8d8;
+        border-right: 1px solid #d8d8d8;
+        box-sizing: border-box;
+        color: $gray-600;
 
         display: block;
         height: 47px;
-        width: 60px;
-        box-sizing: border-box;
-        text-align: center;
-        position: relative;
-        color: $gray-600;
-        border-right: 1px solid #D8D8D8;
-        border-left: 1px solid #D8D8D8;
         margin-left: -1px; /* we have to do this tomfoolery because of user-added menus */
+        position: relative;
+        text-align: center;
         text-decoration: none;
+        width: 60px;
 
-        i, img {
+        i,
+        img {
+          height: 14px;
+          left: 23px;
           position: absolute;
           top: 17px;
-          left: 23px;
           width: 14px;
-          height: 14px;
         }
 
         svg {
+          fill: $gray-600;
+          height: 20px;
+          left: 23px;
           position: absolute;
           top: 17px;
-          left: 23px;
-          width: 20px;
-          height: 20px;
-          fill: $gray-600;
 
           transition: fill 0.25s ease-in-out;
+          width: 20px;
         }
 
       }
 
       > a:hover {
-        color: $gray-900;
         background-color: $gray-200;
+        color: $gray-900;
       }
 
-      > a.ccm-launch-panel-active, > a.ccm-launch-panel-active:hover {
-        color: #ffffff;
+      > a.ccm-launch-panel-active,
+      > a.ccm-launch-panel-active:hover {
+        background-color: $blue;
+        color: #fff;
         transition: background-color 0.25s ease-in-out;
 
         i {
@@ -102,24 +109,22 @@ div#ccm-toolbar {
         }
 
         svg {
-          fill: #ffffff;
+          fill: #fff;
         }
-        background-color: $blue;
       }
 
 
     }
 
     li.ccm-toolbar-button-with-text {
-
       > a {
+        padding: 10px 18px 0 50px;
         width: auto;
-        padding: 10px 18px 0px 50px;
 
         span {
+          font-size: 0.8rem;
           font-weight: bold;
           text-transform: uppercase;
-          font-size: 0.8rem;
         }
       }
 
@@ -127,11 +132,11 @@ div#ccm-toolbar {
 
     li.ccm-logo {
       span {
-        padding: 10px 18px 0px 18px;
+        border-right: 1px solid #d8d8d8;
         display: block;
         height: 47px;
+        padding: 10px 18px 0;
         width: 60px;
-        border-right: 1px solid #D8D8D8;
 
         img {
           height: 23px;
@@ -141,28 +146,28 @@ div#ccm-toolbar {
 
     li.ccm-toolbar-search {
       background-color: #fff;
-      padding: 0px;
-      height: 47px;
-      white-space: nowrap;
-      border-left: 1px solid #D8D8D8;
+      border-left: 1px solid #d8d8d8;
       color: #888;
-      position: relative;
+      height: 47px;
       margin-left: -1px;
+      padding: 0;
+      position: relative;
+      white-space: nowrap;
 
       svg {
+        fill: $gray-600;
+        height: 20px;
+        left: 16px;
         position: absolute;
         top: 16px;
-        left: 16px;
         width: 20px;
-        height: 20px;
-        fill: $gray-600;
       }
 
       input {
-        border-right: 1px solid #D8D8D8;
-        margin-right: 0px;
-        padding-right: 10px;
         background-color: transparent;
+        border-right: 1px solid #d8d8d8;
+        margin-right: 0;
+        padding-right: 10px;
       }
 
     }
@@ -170,28 +175,37 @@ div#ccm-toolbar {
     li.ccm-toolbar-page-edit-mode-active {
       > a {
         background-color: $green;
+
         svg {
           fill: white;
         }
       }
     }
 
-    li.ccm-toolbar-page-edit-mode-pinned{
-      > a, a:hover {
-        background-color: #D6E6EE;
+    li.ccm-toolbar-page-edit-mode-pinned {
+      > a,
+      a:hover {
         @include gradient-y(#D6E6EE, #B8DCEE);
-        color: #136CC0;
+        background-color: #d6e6ee;
+        color: #136cc0;
       }
     }
 
     > li#ccm-white-label-message {
+      border-right: 0 !important;
+
+      color: #ccc;
+      font-size: $font-size-sm;
+      height: 30px;
+      line-height: $line-height-sm;
+      padding: 18px 24px 0;
 
       > a {
+        border: 0;
+        color: #d8d8d8;
         display: inline;
-        border: 0px;
+        padding: 0;
         text-decoration: underline;
-        padding: 0px;
-        color: #D8D8D8;
       }
 
       > a:hover {
@@ -199,59 +213,54 @@ div#ccm-toolbar {
         background-image: none !important;
         text-decoration: underline;
       }
-
-      color: #ccc;
-      font-size: $font-size-sm;
-      line-height: $line-height-sm;
-      padding: 18px 24px 0px 24px;
-      height: 30px;
-      border-right: 0px !important;
     }
 
   }
 
   input[type=search] {
-    margin: 0px 0px 0px 40px;
     height: 47px;
+    margin: 0 0 0 40px;
+    padding: 0;
     width: 210px;
-    padding: 0px;
   }
 
-  input[type=search], textarea {
-    border: 0px;
+  input[type=search],
+  textarea {
+    border: 0;
     border-radius: 0;
     box-shadow: none;
   }
 
-  input[type=search]:focus, textarea:focus {
+  input[type=search]:focus,
+  textarea:focus {
     -webkit-appearance: none !important;
     outline: none !important;
   }
 
   .dropdown-menu {
+    border-top: 0;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    border-top: 0;
 
   }
 
   li.ccm-toolbar-last-left-child {
-    border-right: 1px solid #D8D8D8;
+    border-right: 1px solid #d8d8d8;
   }
 
   /* Multisite List Item Menu Component */
 
   a.ccm-menu-item-site-list-container {
+    text-align: left;
 
     width: 240px;
-    text-align: left;
 
     .selectize-input {
       background-color: transparent;
       border: 1px;
+      box-shadow: none !important;
       height: 46px;
       padding-left: 40px;
-      box-shadow: none !important;
 
       div.item {
         margin-top: 5px;
@@ -265,19 +274,18 @@ div#ccm-toolbar {
   }
 
   a.ccm-menu-item-site-list {
-
     span.ccm-toolbar-accessibility-title {
-      display: inline-block;
       color: #333;
+      display: inline-block;
       position: absolute;
     }
 
   }
 
   li > a.ccm-menu-item-site-list {
-    width: 240px;
-    text-align: left;
     padding: 14px 16px 14px 36px;
+    text-align: left;
+    width: 240px;
   }
 
   &.titles li > a.ccm-menu-item-site-list {
@@ -295,33 +303,36 @@ div#ccm-toolbar {
 
 /* Disabling the toolbar */
 div#ccm-toolbar-disabled {
-  height: 49px;
   background-color: rgba(255, 255, 255, 0.8);
-  z-index: $index-level-toolbar-disabled; /* right over the toolbar */
-  position: fixed;
-  top: 0px;
-  left: 0px;
-  width: 100%;
+  height: 49px;
+  left: 0;
   opacity: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: $index-level-toolbar-disabled; /* right over the toolbar */
 }
 
 /* Responsive Toolbar */
 
 .ccm-toolbar-mobile-menu-button {
+  border-left: 1px solid #d8d8d8;
+  cursor: pointer;
+  height: 47px;
+  padding: 14px 18px;
+
   i {
     font-size: $font-size-lg;
   }
-  padding: 14px 18px;
-  height: 47px;
-  border-left: 1px solid #D8D8D8;
-  cursor: pointer;
+
   &:hover,
   &.ccm-mobile-close {
     color: #7d7d7d;
   }
+
   &.ccm-toolbar-mobile-menu-button-active {
-    background-color: #b5eeb5;
     @include gradient-y(#c2ffc2, #b5eeb5);
+    background-color: #b5eeb5;
   }
 }
 
@@ -331,16 +342,16 @@ div#ccm-toolbar-disabled {
 }
 
 .ccm-mobile-menu-overlay {
-  padding: 15px 0;
-  display: none;
-  background-color: #FCFCFC;
-  position: fixed;
+  background-color: #fcfcfc;
   border-bottom: 5px solid #4674a1;
+  display: none;
+  left: 0;
+  overflow-y: scroll;
+  padding: 15px 0;
+  position: fixed;
+  top: 48px;
   width: 100%;
   z-index: $index-level-main-bar;
-  top: 48px;
-  left: 0px;
-  overflow-y: scroll;
 
   &.ccm-mobile-menu-overlay-dashboard {
     // level 1 navigation link
@@ -360,20 +371,20 @@ div#ccm-toolbar-disabled {
   }
 
   .ccm-mobile-menu-entries {
-    padding-left: 0px;
-    margin-left: 12px;
-    -webkit-text-size-adjust: none;
     list-style-type: none;
+    margin-left: 12px;
+    padding-left: 0;
+    -webkit-text-size-adjust: none;
 
     li {
       &.ccm-toolbar-page-edit-mode-active {
         a {
-          color: #00cc66;
+          color: #0c6;
         }
 
         i {
           &.fa-pencil {
-            color: #00cc66;
+            color: #0c6;
           }
         }
       }
@@ -390,11 +401,11 @@ div#ccm-toolbar-disabled {
 
         li {
           a {
-            text-transform: none;
-            color: #4674a1;
-            padding: 12px 5px;
-            font-weight: normal;
             background: none;
+            color: #4674a1;
+            font-weight: normal;
+            padding: 12px 5px;
+            text-transform: none;
           }
 
           ul {
@@ -412,8 +423,8 @@ div#ccm-toolbar-disabled {
         }
 
         &.mobile-leading-icon {
+          color: #cac9c9;
           display: inline-block !important;
-          color: #CAC9C9;
           min-width: 30px;
           text-align: center;
         }
@@ -422,9 +433,9 @@ div#ccm-toolbar-disabled {
       a {
         color: #4674a1;
         display: inline-block;
-        padding: 8px 5% 8px 15px;
-        height: 100%;
         font-weight: 200;
+        height: 100%;
+        padding: 8px 5% 8px 15px;
         text-decoration: none;
         vertical-align: middle;
 

--- a/assets/cms/scss/_tooltips.scss
+++ b/assets/cms/scss/_tooltips.scss
@@ -1,6 +1,6 @@
 .ccm-ui {
   i.fa.launch-tooltip {
-    border-bottom: 0px;
+    border-bottom: 0;
     text-decoration: none;
   }
 
@@ -8,9 +8,9 @@
     legend {
       i.launch-tooltip {
         color: #ccc;
+        left: -26px;
         position: absolute;
         top: 4px;
-        left: -26px;
       }
     }
   }
@@ -19,15 +19,15 @@
  * Tooltips
  */
 div#ccm-tooltip-holder {
-  z-index: $index-level-tooltip-holder;
   position: relative;
+  z-index: $index-level-tooltip-holder;
 }
 
 div.tooltip-inner {
   font-size: $font-size-sm;
-  line-height: $line-height-sm;
   font-weight: 300;
-  padding: 7px 10px;
+  line-height: $line-height-sm;
   max-width: 250px;
+  padding: 7px 10px;
 }
 

--- a/assets/cms/scss/_type.scss
+++ b/assets/cms/scss/_type.scss
@@ -1,5 +1,4 @@
 div.ccm-ui {
-
   h1 {
     font-weight: bold;
   }

--- a/assets/cms/scss/_variables.scss
+++ b/assets/cms/scss/_variables.scss
@@ -1,7 +1,7 @@
 /** Override bootstrap headings */
 
 /* panels */
-$panel-background-color: #FAFBFC;
+$panel-background-color: #fafbfc;
 
 /* headings */
 $h1-font-size: $font-size-base * 3.5;
@@ -12,7 +12,7 @@ $h5-font-size: $font-size-base * 1.25;
 $h6-font-size: $font-size-base * 0.8;
 
 /* special dialog variables */
-$modal-box-shadow: 0px 2px 4px 2px rgba(0,0,0,0.2);
+$modal-box-shadow: 0 2px 4px 2px rgba(0, 0, 0, 0.2);
 $modal-header-bg: $blue;
 $modal-title-font-size: 1.5rem;
 $modal-title-font-weight: 300;

--- a/assets/cms/scss/bootstrap/_reboot-tags.scss
+++ b/assets/cms/scss/bootstrap/_reboot-tags.scss
@@ -1,7 +1,17 @@
+/* stylelint-disable property-no-vendor-prefix */
 // Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
 // TODO: remove in v5
 // stylelint-disable-next-line selector-list-comma-newline-after
-article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
+article,
+aside,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section {
   display: block;
 }
 
@@ -10,7 +20,7 @@ article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
 // might still respond to pointer events.
 //
 // Credit: https://github.com/suitcss/base
-[tabindex="-1"]:focus {
+[tabindex='-1']:focus {
   outline: 0 !important;
 }
 
@@ -36,9 +46,14 @@ hr {
 // By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
 // margin for easier control within type scales as it avoids margin collapsing.
 // stylelint-disable-next-line selector-list-comma-newline-after
-h1, h2, h3, h4, h5, h6 {
-  margin-top: 0;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin-bottom: $headings-margin-bottom;
+  margin-top: 0;
 }
 
 // Reset margins on paragraphs
@@ -46,8 +61,8 @@ h1, h2, h3, h4, h5, h6 {
 // Similarly, the top margin on `<p>`s get reset. However, we also reset the
 // bottom margin to use `rem` units instead of `em`.
 p {
-  margin-top: 0;
   margin-bottom: $paragraph-margin-bottom;
+  margin-top: 0;
 }
 
 // Abbreviations
@@ -60,24 +75,24 @@ p {
 
 abbr[title],
 abbr[data-original-title] { // 1
+  border-bottom: 0; // 4
+  cursor: help; // 3
   text-decoration: underline; // 2
   text-decoration: underline dotted; // 2
-  cursor: help; // 3
-  border-bottom: 0; // 4
   text-decoration-skip-ink: none; // 5
 }
 
 address {
-  margin-bottom: 1rem;
   font-style: normal;
   line-height: inherit;
+  margin-bottom: 1rem;
 }
 
 ol,
 ul,
 dl {
-  margin-top: 0;
   margin-bottom: 1rem;
+  margin-top: 0;
 }
 
 ol ol,
@@ -92,7 +107,7 @@ dt {
 }
 
 dd {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   margin-left: 0; // Undo browser default
 }
 
@@ -116,14 +131,14 @@ small {
 
 sub,
 sup {
-  position: relative;
   @include font-size(75%);
   line-height: 0;
+  position: relative;
   vertical-align: baseline;
 }
 
-sub { bottom: -.25em; }
-sup { top: -.5em; }
+sub { bottom: -0.25em; }
+sup { top: -0.5em; }
 
 
 //
@@ -131,9 +146,9 @@ sup { top: -.5em; }
 //
 
 a {
+  background-color: transparent; // Remove the gray background on active links in IE 10.
   color: $link-color;
   text-decoration: $link-decoration;
-  background-color: transparent; // Remove the gray background on active links in IE 10.
 
   @include hover {
     color: $link-hover-color;
@@ -170,15 +185,15 @@ pre,
 code,
 kbd,
 samp {
-  font-family: $font-family-monospace;
   @include font-size(1em); // Correct the odd `em` font sizing in all browsers.
+  font-family: $font-family-monospace;
 }
 
 pre {
-  // Remove browser default top margin
-  margin-top: 0;
   // Reset browser default of `1em` to use `rem`s
   margin-bottom: 1rem;
+  // Remove browser default top margin
+  margin-top: 0;
   // Don't allow content to break outside
   overflow: auto;
 }
@@ -199,8 +214,8 @@ figure {
 //
 
 img {
-  vertical-align: middle;
   border-style: none; // Remove the border on images inside links in IE 10-.
+  vertical-align: middle;
 }
 
 svg {
@@ -220,11 +235,11 @@ table {
 }
 
 caption {
-  padding-top: $table-cell-padding;
-  padding-bottom: $table-cell-padding;
-  color: $table-caption-color;
-  text-align: left;
   caption-side: bottom;
+  color: $table-caption-color;
+  padding-bottom: $table-cell-padding;
+  padding-top: $table-cell-padding;
+  text-align: left;
 }
 
 th {
@@ -266,10 +281,10 @@ button,
 select,
 optgroup,
 textarea {
-  margin: 0; // Remove the margin in Firefox and Safari
-  font-family: inherit;
   @include font-size(inherit);
+  font-family: inherit;
   line-height: inherit;
+  margin: 0; // Remove the margin in Firefox and Safari
 }
 
 button,
@@ -294,18 +309,19 @@ select {
 //    controls in Android 4.
 // 2. Correct the inability to style clickable types in iOS and Safari.
 button,
-[type="button"], // 1
-[type="reset"],
-[type="submit"] {
+[type='button'],
+ 
+[type='reset'],
+[type='submit'] {
   -webkit-appearance: button; // 2
 }
 
 // Opinionated: add "hand" cursor to non-disabled button elements.
 @if $enable-pointer-cursor-for-buttons {
   button,
-  [type="button"],
-  [type="reset"],
-  [type="submit"] {
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
     &:not(:disabled) {
       cursor: pointer;
     }
@@ -314,24 +330,24 @@ button,
 
 // Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
 button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
-  padding: 0;
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
   border-style: none;
+  padding: 0;
 }
 
-input[type="radio"],
-input[type="checkbox"] {
+input[type='radio'],
+input[type='checkbox'] {
   box-sizing: border-box; // 1. Add the correct box sizing in IE 10-
   padding: 0; // 2. Remove the padding in IE 10-
 }
 
 
-input[type="date"],
-input[type="time"],
-input[type="datetime-local"],
-input[type="month"] {
+input[type='date'],
+input[type='time'],
+input[type='datetime-local'],
+input[type='month'] {
   // Remove the default appearance of temporal inputs to avoid a Mobile Safari
   // bug where setting a custom line-height prevents text from being vertically
   // centered within the input.
@@ -347,6 +363,8 @@ textarea {
 }
 
 fieldset {
+  border: 0;
+  margin: 0;
   // Browsers set a default `min-width: min-content;` on fieldsets,
   // unlike e.g. `<div>`s, which have `min-width: 0;` by default.
   // So we reset that to ensure fieldsets behave more like a standard block element.
@@ -355,22 +373,20 @@ fieldset {
   min-width: 0;
   // Reset the default outline behavior of fieldsets so they don't affect page layout.
   padding: 0;
-  margin: 0;
-  border: 0;
 }
 
 // 1. Correct the text wrapping in Edge and IE.
 // 2. Correct the color inheritance from `fieldset` elements in IE.
 legend {
+  @include font-size(1.5rem);
+  color: inherit; // 2
   display: block;
-  width: 100%;
+  line-height: inherit;
+  margin-bottom: 0.5rem;
   max-width: 100%; // 1
   padding: 0;
-  margin-bottom: .5rem;
-  @include font-size(1.5rem);
-  line-height: inherit;
-  color: inherit; // 2
   white-space: normal; // 1
+  width: 100%;
 }
 
 progress {
@@ -378,25 +394,25 @@ progress {
 }
 
 // Correct the cursor style of increment and decrement buttons in Chrome.
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
   height: auto;
 }
 
-[type="search"] {
+[type='search'] {
+  -webkit-appearance: none;
   // This overrides the extra rounded corners on search inputs in iOS so that our
   // `.form-control` class can properly style them. Note that this cannot simply
   // be added to `.form-control` as it's not specific enough. For details, see
   // https://github.com/twbs/bootstrap/issues/11586.
   outline-offset: -2px; // 2. Correct the outline style in Safari.
-  -webkit-appearance: none;
 }
 
 //
 // Remove the inner padding in Chrome and Safari on macOS.
 //
 
-[type="search"]::-webkit-search-decoration {
+[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
@@ -406,8 +422,8 @@ progress {
 //
 
 ::-webkit-file-upload-button {
-  font: inherit; // 2
   -webkit-appearance: button; // 1
+  font: inherit; // 2
 }
 
 //
@@ -419,8 +435,8 @@ output {
 }
 
 summary {
-  display: list-item; // Add the correct display in all browsers
   cursor: pointer;
+  display: list-item; // Add the correct display in all browsers
 }
 
 template {

--- a/assets/cms/scss/bootstrap/_reboot.scss
+++ b/assets/cms/scss/bootstrap/_reboot.scss
@@ -1,14 +1,14 @@
 .ccm-ui {
-  box-sizing: border-box; // 1
-  font-family: sans-serif; // 2
-  line-height: 1.15; // 3
-  -webkit-text-size-adjust: 100%; // 4
-  -webkit-tap-highlight-color: rgba($black, 0); // 5
-  margin: 0; // 1
-  font-family: $font-family-base;
   @include font-size('16px'); // The reboot used by cms.css needs to have the font size set explicitly in case the container theme sets weird CSS
-  font-weight: $font-weight-base;
-  line-height: $line-height-base;
+  box-sizing: border-box; // 1
   color: $body-color;
+  font-family: sans-serif; // 2
+  font-family: $font-family-base;
+  font-weight: $font-weight-base;
+  line-height: 1.15; // 3
+  line-height: $line-height-base;
+  margin: 0; // 1
+  -webkit-tap-highlight-color: rgba($black, 0); // 5
   text-align: left; // 3
+  text-size-adjust: 100%; // 4
 }

--- a/assets/cms/scss/jquery-ui/_overrides.scss
+++ b/assets/cms/scss/jquery-ui/_overrides.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable declaration-property-value-blacklist */
 // Note: these are not SASS overrides in the traditional sense. Since jQuery just imports
 // via base CSS, we have to do CSS based overrides for the concrete5 stuff.
 
@@ -7,16 +8,16 @@ html.ccm-toolbar-visible {
   }
 
   .ui-dialog {
+    box-shadow: $modal-box-shadow;
+    padding: 0;
+
+    z-index: $index-level-dialog;
     /* hide section titles for panels when those panels are shown in dialogs */
     section {
       header {
         display: none;
       }
     }
-
-    z-index: $index-level-dialog;
-    box-shadow: $modal-box-shadow;
-    padding: 0;
 
     &.ui-widget-content {
       border: none;
@@ -28,12 +29,12 @@ html.ccm-toolbar-visible {
     }
 
     .ui-dialog-titlebar {
-      padding: $modal-header-padding-y $modal-header-padding-x;
+      align-items: flex-start;
       background-color: $modal-header-bg;
       color: $modal-title-color;
       display: flex;
-      align-items: flex-start;
       justify-content: space-between;
+      padding: $modal-header-padding-y $modal-header-padding-x;
 
       span {
         font-size: $modal-title-font-size;
@@ -43,55 +44,55 @@ html.ccm-toolbar-visible {
       }
 
       &.ui-widget-header {
-        border: 0px;
+        border: 0;
       }
 
       &.ui-corner-all {
-        border-radius: 0px;
+        border-radius: 0;
       }
 
       .ui-dialog-title {
         float: none;
-        margin: 0px;
+        margin: 0;
       }
 
 
       button.ui-dialog-titlebar-close {
         svg {
-          width: 24px;
           height: 24px;
+          width: 24px;
         }
       }
 
       button.ui-dialog-titlebar-help {
         svg {
-          width: 20px;
           height: 20px;
+          width: 20px;
         }
       }
 
 
       button {
-        position: static;
-        border: 0px;
         background: transparent;
+        border: 0;
+        color: white;
         float: right;
         font-size: 1.5rem;
-        width: auto;
         height: auto;
         line-height: 1;
-        padding: $modal-header-padding;
         margin: (-$modal-header-padding-y) (-$modal-header-padding-x) (-$modal-header-padding-y) auto;
 
 
         opacity: 1;
-        color: white;
+        padding: $modal-header-padding;
+        position: static;
         transition: color 0.1s ease-in-out;
+        width: auto;
 
         &:not(:disabled):not(.disabled) {
           @include hover-focus() {
-            opacity: 1;
             color: $gray-600;
+            opacity: 1;
 
             svg {
               fill: $gray-600;
@@ -123,8 +124,8 @@ html.ccm-toolbar-visible {
   }
 
   .ui-widget-overlay {
-    transition: $transition-fade;
     opacity: 0;
+    transition: $transition-fade;
 
     &.ui-widget-overlay-active {
       background: $modal-backdrop-bg;
@@ -133,16 +134,16 @@ html.ccm-toolbar-visible {
   }
 
   .ui-dialog-buttonpane {
-    // copied from the .modal-footer in bootstrap
-    padding: 0px;
-    margin-top: 0px;
-    border-width: 0px;
+    align-items: center;
+    border-top: $modal-footer-border-width solid $modal-footer-border-color;
+    border-width: 0;
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
     justify-content: flex-end;
+    margin-top: 0;
+    // copied from the .modal-footer in bootstrap
+    padding: 0;
     padding: $modal-inner-padding - $modal-footer-margin-between / 2;
-    border-top: $modal-footer-border-width solid $modal-footer-border-color;
 
     button {
       margin: $modal-footer-margin-between / 2;

--- a/assets/cms/scss/jquery-ui/_theme.scss
+++ b/assets/cms/scss/jquery-ui/_theme.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable property-no-vendor-prefix */
 /*!
  * jQuery UI CSS Framework 1.12.1
  * http://jqueryui.com
@@ -18,9 +19,11 @@
   font-family: Arial,Helvetica,sans-serif/*{ffDefault}*/;
   font-size: 1em/*{fsDefault}*/;
 }
+
 .ui-widget .ui-widget {
   font-size: 1em;
 }
+
 .ui-widget input,
 .ui-widget select,
 .ui-widget textarea,
@@ -28,25 +31,30 @@
   font-family: Arial,Helvetica,sans-serif/*{ffDefault}*/;
   font-size: 1em;
 }
+
 .ui-widget.ui-widget-content {
   border: 1px solid #c5c5c5/*{borderColorDefault}*/;
 }
+
 .ui-widget-content {
-  border: 1px solid #dddddd/*{borderColorContent}*/;
-  background: #ffffff/*{bgColorContent}*/ /*{bgImgUrlContent}*/ /*{bgContentXPos}*/ /*{bgContentYPos}*/ /*{bgContentRepeat}*/;
-  color: #333333/*{fcContent}*/;
+  background: #fff;
+  border: 1px solid #ddd;
+  color: #333;
 }
+
 .ui-widget-content a {
-  color: #333333/*{fcContent}*/;
+  color: #333;
 }
+
 .ui-widget-header {
-  border: 1px solid #dddddd/*{borderColorHeader}*/;
   background: #e9e9e9/*{bgColorHeader}*/ /*{bgImgUrlHeader}*/ /*{bgHeaderXPos}*/ /*{bgHeaderYPos}*/ /*{bgHeaderRepeat}*/;
-  color: #333333/*{fcHeader}*/;
+  border: 1px solid #ddd;
+  color: #333;
   font-weight: bold;
 }
+
 .ui-widget-header a {
-  color: #333333/*{fcHeader}*/;
+  color: #333;
 }
 
 /* Interaction states
@@ -60,11 +68,12 @@
   works properly when clicked or hovered */
 html .ui-button.ui-state-disabled:hover,
 html .ui-button.ui-state-disabled:active {
-  border: 1px solid #c5c5c5/*{borderColorDefault}*/;
   background: #f6f6f6/*{bgColorDefault}*/ /*{bgImgUrlDefault}*/ /*{bgDefaultXPos}*/ /*{bgDefaultYPos}*/ /*{bgDefaultRepeat}*/;
-  font-weight: normal/*{fwDefault}*/;
+  border: 1px solid #c5c5c5/*{borderColorDefault}*/;
   color: #454545/*{fcDefault}*/;
+  font-weight: normal/*{fwDefault}*/;
 }
+
 .ui-state-default a,
 .ui-state-default a:link,
 .ui-state-default a:visited,
@@ -75,6 +84,7 @@ a:visited.ui-button,
   color: #454545/*{fcDefault}*/;
   text-decoration: none;
 }
+
 .ui-state-hover,
 .ui-widget-content .ui-state-hover,
 .ui-widget-header .ui-state-hover,
@@ -83,11 +93,12 @@ a:visited.ui-button,
 .ui-widget-header .ui-state-focus,
 .ui-button:hover,
 .ui-button:focus {
-  border: 1px solid #cccccc/*{borderColorHover}*/;
   background: #ededed/*{bgColorHover}*/ /*{bgImgUrlHover}*/ /*{bgHoverXPos}*/ /*{bgHoverYPos}*/ /*{bgHoverRepeat}*/;
-  font-weight: normal/*{fwDefault}*/;
+  border: 1px solid #ccc;
   color: #2b2b2b/*{fcHover}*/;
+  font-weight: normal/*{fwDefault}*/;
 }
+
 .ui-state-hover a,
 .ui-state-hover a:hover,
 .ui-state-hover a:link,
@@ -105,26 +116,29 @@ a.ui-button:focus {
 .ui-visual-focus {
   box-shadow: 0 0 3px 1px rgb(94, 158, 214);
 }
+
 .ui-state-active,
 .ui-widget-content .ui-state-active,
 .ui-widget-header .ui-state-active,
 a.ui-button:active,
 .ui-button:active,
 .ui-button.ui-state-active:hover {
-  border: 1px solid #003eff/*{borderColorActive}*/;
   background: #007fff/*{bgColorActive}*/ /*{bgImgUrlActive}*/ /*{bgActiveXPos}*/ /*{bgActiveYPos}*/ /*{bgActiveRepeat}*/;
+  border: 1px solid #003eff/*{borderColorActive}*/;
+  color: #fff;
   font-weight: normal/*{fwDefault}*/;
-  color: #ffffff/*{fcActive}*/;
 }
+
 .ui-icon-background,
 .ui-state-active .ui-icon-background {
+  background-color: #fff;
   border: #003eff/*{borderColorActive}*/;
-  background-color: #ffffff/*{fcActive}*/;
 }
+
 .ui-state-active a,
 .ui-state-active a:link,
 .ui-state-active a:visited {
-  color: #ffffff/*{fcActive}*/;
+  color: #fff;
   text-decoration: none;
 }
 
@@ -133,57 +147,66 @@ a.ui-button:active,
 .ui-state-highlight,
 .ui-widget-content .ui-state-highlight,
 .ui-widget-header .ui-state-highlight {
-  border: 1px solid #dad55e/*{borderColorHighlight}*/;
   background: #fffa90/*{bgColorHighlight}*/ /*{bgImgUrlHighlight}*/ /*{bgHighlightXPos}*/ /*{bgHighlightYPos}*/ /*{bgHighlightRepeat}*/;
+  border: 1px solid #dad55e/*{borderColorHighlight}*/;
   color: #777620/*{fcHighlight}*/;
 }
+
 .ui-state-checked {
-  border: 1px solid #dad55e/*{borderColorHighlight}*/;
   background: #fffa90/*{bgColorHighlight}*/;
+  border: 1px solid #dad55e/*{borderColorHighlight}*/;
 }
+
 .ui-state-highlight a,
 .ui-widget-content .ui-state-highlight a,
 .ui-widget-header .ui-state-highlight a {
   color: #777620/*{fcHighlight}*/;
 }
+
 .ui-state-error,
 .ui-widget-content .ui-state-error,
 .ui-widget-header .ui-state-error {
-  border: 1px solid #f1a899/*{borderColorError}*/;
   background: #fddfdf/*{bgColorError}*/ /*{bgImgUrlError}*/ /*{bgErrorXPos}*/ /*{bgErrorYPos}*/ /*{bgErrorRepeat}*/;
+  border: 1px solid #f1a899/*{borderColorError}*/;
   color: #5f3f3f/*{fcError}*/;
 }
+
 .ui-state-error a,
 .ui-widget-content .ui-state-error a,
 .ui-widget-header .ui-state-error a {
   color: #5f3f3f/*{fcError}*/;
 }
+
 .ui-state-error-text,
 .ui-widget-content .ui-state-error-text,
 .ui-widget-header .ui-state-error-text {
   color: #5f3f3f/*{fcError}*/;
 }
+
 .ui-priority-primary,
 .ui-widget-content .ui-priority-primary,
 .ui-widget-header .ui-priority-primary {
   font-weight: bold;
 }
+
 .ui-priority-secondary,
 .ui-widget-content .ui-priority-secondary,
 .ui-widget-header .ui-priority-secondary {
-  opacity: .7;
-  filter:Alpha(Opacity=70); /* support: IE8 */
+  filter: Alpha(Opacity=70); /* support: IE8 */
   font-weight: normal;
+  opacity: 0.7;
 }
+
 .ui-state-disabled,
 .ui-widget-content .ui-state-disabled,
 .ui-widget-header .ui-state-disabled {
-  opacity: .35;
-  filter:Alpha(Opacity=35); /* support: IE8 */
   background-image: none;
+  filter: Alpha(Opacity=35); /* support: IE8 */
+  opacity: 0.35;
 }
+
 .ui-state-disabled .ui-icon {
-  filter:Alpha(Opacity=35); /* support: IE8 - See #6059 */
+  filter: Alpha(Opacity=35); /* support: IE8 - See #6059 */
 }
 
 /* Misc visuals
@@ -196,18 +219,21 @@ a.ui-button:active,
 .ui-corner-tl {
   border-top-left-radius: 3px/*{cornerRadius}*/;
 }
+
 .ui-corner-all,
 .ui-corner-top,
 .ui-corner-right,
 .ui-corner-tr {
   border-top-right-radius: 3px/*{cornerRadius}*/;
 }
+
 .ui-corner-all,
 .ui-corner-bottom,
 .ui-corner-left,
 .ui-corner-bl {
   border-bottom-left-radius: 3px/*{cornerRadius}*/;
 }
+
 .ui-corner-all,
 .ui-corner-bottom,
 .ui-corner-right,
@@ -217,11 +243,12 @@ a.ui-button:active,
 
 /* Overlays */
 .ui-widget-overlay {
-  background: #aaaaaa/*{bgColorOverlay}*/ /*{bgImgUrlOverlay}*/ /*{bgOverlayXPos}*/ /*{bgOverlayYPos}*/ /*{bgOverlayRepeat}*/;
-  opacity: .3/*{opacityOverlay}*/;
+  background: #aaa;
   filter: Alpha(Opacity=30)/*{opacityFilterOverlay}*/; /* support: IE8 */
+  opacity: 0.3;
 }
+
 .ui-widget-shadow {
-  -webkit-box-shadow: 0/*{offsetLeftShadow}*/ 0/*{offsetTopShadow}*/ 5px/*{thicknessShadow}*/ #666666/*{bgColorShadow}*/;
-  box-shadow: 0/*{offsetLeftShadow}*/ 0/*{offsetTopShadow}*/ 5px/*{thicknessShadow}*/ #666666/*{bgColorShadow}*/;
+  -webkit-box-shadow: 0 0 5px #666#666;
+  box-shadow: 0 0 5px #666#666;
 }

--- a/assets/cms/scss/mixins/_item-select-list-hover.scss
+++ b/assets/cms/scss/mixins/_item-select-list-hover.scss
@@ -1,7 +1,7 @@
 @mixin item-select-list-hover() {
-  color: $body-color;
   background-color: #e7e7e7;
-  text-decoration: none;
   border-radius: 4px;
+  color: $body-color;
+  text-decoration: none;
   transition: background-color 0.1s linear;
 }

--- a/assets/cms/scss/panels/_shared.scss
+++ b/assets/cms/scss/panels/_shared.scss
@@ -4,36 +4,34 @@ html.ccm-panel-detail-open {
   }
 
   .ccm-panel-detail {
-    position: fixed;
-    top: 0;
     left: 0;
     overflow: auto;
+    position: fixed;
+    top: 0;
   }
 }
 
 div.ccm-panel {
   background-color: $panel-background-color;
-  width: 320px;
   height: 100%;
-  position: fixed;
-  top: 0px;
-  z-index: $index-level-panel; // has to come above the detail actions wrapper
   overflow: hidden;
+  position: fixed;
+  top: 0;
   user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
+  width: 320px;
+  z-index: $index-level-panel; // has to come above the detail actions wrapper
 }
 
 div#ccm-panel-overlay {
-  z-index: $index-level-panel-overlay;
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  display: none;
   background: transparent;
-  transition: background-color cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
+  display: none;
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transition: background-color cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
+  width: 100%;
+  z-index: $index-level-panel-overlay;
 }
 
 div#ccm-panel-overlay.ccm-panel-translucent {
@@ -42,7 +40,7 @@ div#ccm-panel-overlay.ccm-panel-translucent {
 
 html.ccm-panel-ready {
   div.ccm-page {
-    transition: transform cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
+    transition: transform cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
   }
 }
 
@@ -84,9 +82,9 @@ div.ccm-panel-transition-none.ccm-panel-left.ccm-panel-active {
 }
 
 div.ccm-panel-transition-slide.ccm-panel-left {
+  left: 0;
   transform: translate(-100%, 0);
-  left: 0px;
-  transition: transform cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
+  transition: transform cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
 
 }
 
@@ -99,9 +97,9 @@ div.ccm-panel-transition-none.ccm-panel-right.ccm-panel-active {
 }
 
 div.ccm-panel-transition-slide.ccm-panel-right {
+  right: 0;
   transform: translate(100%, 0);
-  right: 0px;
-  transition: transform cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
+  transition: transform cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
 }
 
 div.ccm-panel-left.ccm-panel-transition-slide.ccm-panel-active {
@@ -117,51 +115,51 @@ div.ccm-panel-right.ccm-panel-transition-slide.ccm-panel-active {
  */
 
 div.ccm-panel-right.ccm-panel-active {
-  box-shadow: -2px 0px 4px rgba(0, 0, 0, 0.12)
+  box-shadow: -2px 0 4px rgba(0, 0, 0, 0.12);
 }
 
 div.ccm-panel-right {
-  box-shadow: -2px 0px 4px rgba(0, 0, 0, 0.12)
+  box-shadow: -2px 0 4px rgba(0, 0, 0, 0.12);
 }
 
 div.ccm-panel-left {
-  box-shadow: 2px 0px 4px rgba(0, 0, 0, 0.12)
+  box-shadow: 2px 0 4px rgba(0, 0, 0, 0.12);
 }
 
 /**
  * Panel Content
  */
 div.ccm-panel-content {
-  padding: 0px;
+  bottom: 0;
+  left: 0;
   margin-top: 48px;
-  position: absolute;
-  top: 0px;
-  bottom: 0px;
   overflow: auto;
+  padding: 0;
+  position: absolute;
+  top: 0;
+  transition: transform cubic-bezier(0.19, 1, 0.22, 1) 0.5s;
   width: 320px;
-  left: 0px;
-  transition: transform cubic-bezier(0.190, 1.000, 0.220, 1.000) 0.5s;
 
   button.ccm-delete-clipboard-item {
-    color: #A2A3A8;
+    color: #a2a3a8;
 
     &:hover {
-      color: darken(#A2A3A8, 15%);
+      color: darken(#a2a3a8, 15%);
     }
   }
 
   section {
-    padding: 0px;
+    padding: 0;
   }
 }
 
 div.ccm-panel-content {
 
-  padding: 20px 10px 0px 16px;
+  padding: 20px 10px 0 16px;
 
   header {
-    padding: 15px 11px 0px 24px;
     font-weight: 500;
+    padding: 15px 11px 0 24px;
 
     aside {
       float: right;
@@ -175,14 +173,15 @@ div.ccm-panel-content {
     }
   }
 
-  ul.nav, menu {
-
-    padding: 0px;
+  ul.nav,
+  menu {
     border-top: 1px solid $gray-200;
 
+    padding: 0;
+
     > li {
-      margin-top: 0px;
-      margin-left: 0px;
+      margin-left: 0;
+      margin-top: 0;
 
       > ul {
         margin-left: 25px;
@@ -201,14 +200,14 @@ div.ccm-panel-content {
       }
 
       a {
-        display: block;
-        text-decoration: none;
-        padding: 14px 21px 14px 24px;
         color: $gray-600;
+        display: block;
         line-height: 1.8em;
+        padding: 14px 21px 14px 24px;
+        text-decoration: none;
 
         &:hover {
-          background-color: #D2EAFA;
+          background-color: #d2eafa;
         }
 
         &.ccm-panel-menu-item-active {
@@ -224,18 +223,18 @@ div.ccm-panel-content {
       ul {
 
         margin-top: 5px;
-        padding-left: 0px;
+        padding-left: 0;
 
         li {
-          margin-top: 3px;
           margin-left: 20px;
+          margin-top: 3px;
         }
 
         a {
-          border-radius: 0px;
+          border-radius: 0;
           display: inline;
-          padding: 0px;
           font-weight: 400;
+          padding: 0;
 
           &:hover {
             background-color: auto;
@@ -248,22 +247,22 @@ div.ccm-panel-content {
 }
 
 div.ccm-panel-content-inner {
-  padding: 20px 40px 40px 40px;
+  padding: 20px 40px 40px;
 }
 
 /**
  * Panel main detail areas
  */
 div.ccm-panel-detail {
-  z-index: $index-level-panel-detail;
-  width: 100%;
+  background: transparent;
+  box-sizing: border-box;
+  display: none;
   height: 100%;
+  padding-top: 48px;
   position: absolute;
   top: 0;
-  display: none;
-  box-sizing: border-box;
-  background: transparent;
-  padding-top: 48px;
+  width: 100%;
+  z-index: $index-level-panel-detail;
 
   &.ccm-panel-detail-static {
     display: block;
@@ -288,31 +287,30 @@ html.ccm-panel-right div.ccm-panel-detail {
 }
 
 div.ccm-panel-detail-content {
-  padding: 40px 40px 80px 40px;
   background-color: white;
-  min-width: 100%;
   min-height: 100%;
+  min-width: 100%;
+  padding: 40px 40px 80px;
 
   div.ccm-notification-help {
     position: absolute;
-    right: 0px;
+    right: 0;
     top: 110px;
   }
 
   section {
-    padding: 0px;
+    padding: 0;
   }
 
 
 }
 
 div.ccm-panel-detail {
-
   header {
     font-size: $font-size-lg;
+    font-weight: 300;
     margin: -40px -40px 30px -95px;
     padding: 39px 80px 39px 95px;
-    font-weight: 300;
   }
 
   hr {
@@ -326,9 +324,9 @@ div.ccm-panel-detail {
  * Panel Detail Fade
  */
 div.ccm-panel-detail.ccm-panel-detail-transition-fade {
-  transition: opacity 0.5s cubic-bezier(0.190, 1.000, 0.220, 1.000);
-  opacity: 0;
   display: block;
+  opacity: 0;
+  transition: opacity 0.5s cubic-bezier(0.19, 1, 0.22, 1);
 }
 
 div.ccm-panel-detail.ccm-panel-detail-transition-fade-apply {
@@ -342,8 +340,8 @@ div.ccm-panel-detail.ccm-panel-detail-transition-fade-apply {
  */
 
 html.ccm-panel-left div.ccm-page.ccm-panel-detail-transition-swap {
-  position: relative;
   left: 320px;
+  position: relative;
 }
 
 html.ccm-panel-right div.ccm-page.ccm-panel-detail-transition-swap {
@@ -353,18 +351,14 @@ html.ccm-panel-right div.ccm-page.ccm-panel-detail-transition-swap {
 
 html.ccm-panel-ready div.ccm-page.ccm-panel-detail-transition-swap {
   transform: rotateY(0deg);
-  -webkit-transform: rotateY(0deg);
   transition-duration: 0.5s;
-  transition-easing: none;
-  -webkit-transition-easing: none;
+  transition-timing-function: none;
 }
 
 html.ccm-panel-ready div.ccm-page.ccm-panel-detail-transition-swap.ccm-panel-detail-transition-swap-apply {
   transform: rotateY(180deg);
-  -webkit-transform: rotateY(180deg);
   transition-duration: 0.5s;
-  transition-easing: none;
-  -webkit-transition-easing: none;
+  transition-timing-function: none;
 }
 
 div.ccm-panel-detail.ccm-panel-detail-transition-none.ccm-panel-detail-transition-none-apply {
@@ -395,20 +389,19 @@ div.ccm-panel-content-appearing {
 }
 
 div.ccm-panel-content.ccm-panel-content-visible {
-  transform: translate(0px, 0);
+  transform: translate(0, 0);
 }
 
 div.ccm-panel-content {
-
   header {
     a.ccm-panel-back {
+      color: $gray-700;
       display: block;
-      margin-top: -15px;
       margin-bottom: 30px;
+      margin-top: -15px;
+      text-decoration: none;
 
       transition: color 0.1s ease-in-out;
-      color: $gray-700;
-      text-decoration: none;
 
       &:hover {
         color: $blue;
@@ -419,9 +412,9 @@ div.ccm-panel-content {
       }
 
       svg {
-        width: 20px;
         height: 20px;
         transition: fill 0.1s ease-in-out;
+        width: 20px;
       }
     }
 
@@ -432,11 +425,11 @@ div.ccm-panel-content {
  * Forms and button actions
  */
 div.ccm-panel-detail-form-actions {
-  border-top: 1px solid $gray-200;
   background-color: $gray-100;
+  border-top: 1px solid $gray-200;
+  bottom: 0;
+  left: 0;
   padding: 15px 20px 15px 340px;
   position: fixed;
-  bottom: 0px;
-  left: 0px;
   width: 100%;
 }

--- a/assets/cms/scss/panels/_sitemap.scss
+++ b/assets/cms/scss/panels/_sitemap.scss
@@ -3,7 +3,7 @@ div.ccm-panel-content-inner {
     .ccm-sitemap-wrapper {
       .ccm-sitemap-tree {
         ul.fancytree-container {
-          border:none;
+          border: 'none';
         }
       }
     }

--- a/assets/conversations/scss/frontend.scss
+++ b/assets/conversations/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/conversations/scss/frontend/_frontend.scss
+++ b/assets/conversations/scss/frontend/_frontend.scss
@@ -1,30 +1,33 @@
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
-@import "../../../cms/scss/variables";
+/* stylelint-disable selector-max-compound-selectors */
+
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins';
+@import '../../../cms/scss/variables';
 
 div.ccm-conversation-avatar {
-  width: 40px;
-  position: absolute;
-  top: 0px;
-  left: 0px;
+  left: 0;
   margin-right: 10px;
+  position: absolute;
+  top: 0;
+  width: 40px;
 
   img {
     border-radius: 4px;
-    max-width: 40px !important;
     max-height: 40px !important;
+    max-width: 40px !important;
   }
 }
 
 div.ccm-conversation-message-form {
   ul.redactor-toolbar {
-    box-shadow: none;
     border: 1px solid #ddd;
+    box-shadow: none;
   }
+
   .redactor-editor {
-    padding: 10px;
     border: 1px solid #eee;
+    padding: 10px;
   }
 }
 
@@ -32,15 +35,18 @@ div.ccm-conversation-message-form {
   position: absolute;
   right: 0;
   top: -10px;
+
   a.dropdown-toggle {
     font-size: $font-size-sm;
   }
+
   ul.dropdown-menu {
     left: auto;
     right: 0;
 
     a.admin-edit {
-      color: #00cc66;
+      color: #0c6;
+
       &:hover {
         color: white;
       }
@@ -48,6 +54,7 @@ div.ccm-conversation-message-form {
 
     a.admin-delete {
       color: #ff7070;
+
       &:hover {
         color: white;
       }
@@ -57,9 +64,9 @@ div.ccm-conversation-message-form {
 }
 
 div.ccm-conversation-message-count {
+  float: left;
   font-weight: bold;
   margin-top: 20px;
-  float: left;
 }
 
 div.ccm-conversation-messages-header {
@@ -67,20 +74,22 @@ div.ccm-conversation-messages-header {
   margin-bottom: 15px;
 
   select.ccm-sort-conversations {
-    font-size: $font-size-sm;
-    width: auto;
-    margin-top: 10px;
     float: right;
+    font-size: $font-size-sm;
+    margin-top: 10px;
+    width: auto;
   }
 }
 
-div.ccm-conversation-add-reply, div.ccm-conversation-add-new-message, div.ccm-conversation-edit-message {
-  clear: both;
+div.ccm-conversation-add-reply,
+div.ccm-conversation-add-new-message,
+div.ccm-conversation-edit-message {
   @include clearfix();
+  clear: both;
   position: relative;
 
   form {
-    margin-bottom: 0px;
+    margin-bottom: 0;
   }
 
   div.ccm-conversation-avatar + div.ccm-conversation-message-form {
@@ -89,23 +98,26 @@ div.ccm-conversation-add-reply, div.ccm-conversation-add-new-message, div.ccm-co
 
   div.ccm-conversation-message-form {
     @include clearfix();
+
     textarea {
       box-sizing: border-box;
-      width: 100%;
       font-size: $font-size-sm;
       height: 80px;
+      width: 100%;
     }
 
     .ccm-conversation-attachment-toggle {
       float: right;
       opacity: 0.7;
+
       &.btn-success {
-        border-top: 0;
         border-bottom: 0;
+        border-top: 0;
       }
     }
 
-    button, a.btn {
+    button,
+    a.btn {
       margin: 16px 0 0 16px;
     }
   }
@@ -122,6 +134,7 @@ div.ccm-conversation-add-reply {
 
 div.ccm-conversation-attachment-container {
   margin-top: 20px;
+
   .dropzone {
     border: 1px dashed $gray-300;
   }
@@ -132,7 +145,6 @@ div.ccm-conversation-errors {
 }
 
 div.ccm-conversation-message-list {
-
   div.ccm-conversation-delete-message {
     display: none;
   }
@@ -154,76 +166,85 @@ div.ccm-conversation-dialog {
 }
 
 div.ccm-conversation-message.ccm-conversation-message-topic {
-  padding-left: 0px;
+  padding-left: 0;
 }
 
 div.ccm-conversation-message {
-  position: relative;
   @include clearfix();
-  padding-top: 0px;
   padding-bottom: 20px;
-  padding-right: 0px;
   padding-left: 50px;
+  padding-right: 0;
+  padding-top: 0;
+  position: relative;
+
   div.ccm-conversation-message-byline {
-    padding: 0px 8px 8px 8px;
     color: #9f9f9f;
     margin-bottom: 0;
+    padding: 0 8px 8px;
+
     span.ccm-conversation-message-date {
       color: #9f9f9f;
     }
+
     span.ccm-conversation-message-username {
+      color: #09f;
       font-weight: bold;
-      color: #0099ff;
     }
+
     span.ccm-conversation-message-divider {
-      padding: 0px 10px 0px 10px;
+      padding: 0 10px;
     }
 
   }
 
   .message-attachments {
     @include clearfix();
+
     .attachment-container {
-      position: relative;
+      @include clearfix();
       background: #f9f9f9;
-      border: 1px solid #cccccc;
+      border: 1px solid #ccc;
       border-radius: 4px;
       display: block;
-      @include clearfix();
       margin-bottom: 20px;
+      position: relative;
 
       .attachment-preview-container {
-        width: 90px;
-        min-height: 90px;
         float: left;
+        min-height: 90px;
+        width: 90px;
       }
 
       .image-popover-hover {
-        top: 0;
+        background: transparent;
+        border-bottom-left-radius: 4px;
+        border-top-left-radius: 4px;
+        cursor: pointer;
+        height: 90px;
         left: 0;
         position: absolute;
-        background: transparent;
+        top: 0;
         width: 90px;
-        height: 90px;
-        border-top-left-radius: 4px;
-        border-bottom-left-radius: 4px;
-        cursor: pointer;
+
         .glyph-container {
-          padding: 8px 0px 0px 10px;
-          color: #fff;
-          display: none;
-          margin: 29px 0px 0px 27px;
           background-color: black;
           border-radius: 4px;
-          width: 36px;
+          color: #fff;
+          display: none;
           height: 36px;
+          margin: 29px 0 0 27px;
+          padding: 8px 0 0 10px;
+          width: 36px;
+
           i {
             margin-left: 1px;
           }
         }
+
         &:hover {
           background: #0a5d99;
           opacity: 0.8;
+
           .glyph-container {
             display: block;
           }
@@ -231,26 +252,28 @@ div.ccm-conversation-message {
       }
 
       img {
-        float: left;
-        border-top-left-radius: 4px;
         border-bottom-left-radius: 4px;
+        border-top-left-radius: 4px;
+        float: left;
       }
 
       p.image-preview {
         display: block;
         float: left;
-        padding: 20px 0px 10px 20px;
+        padding: 20px 0 10px 20px;
       }
     }
   }
 
   .ccm-conversation-message-body {
-    padding: 0px 8px;
+    padding: 0 8px;
   }
 
   div.ccm-conversation-message-controls {
-    padding: 0px 0px 0px 8px;
+
+    @include clearfix();
     color: #999;
+    padding: 0 0 0 8px;
 
     a.ccm-conversation-message-control-icon {
       color: #999;
@@ -264,12 +287,11 @@ div.ccm-conversation-message {
       display: none;
     }
 
-    @include clearfix();
     span.control-divider {
       display: block;
-      padding: 8px;
       float: left;
       margin-left: 15px;
+      padding: 8px;
     }
 
     li:first-child {
@@ -279,28 +301,24 @@ div.ccm-conversation-message {
     ul {
       float: left;
       list-style-type: none;
-      margin: 0px;
-      padding: 0px;
+      margin: 0;
+      padding: 0;
 
       li {
         display: inline-block;
         margin-left: 20px;
 
         &.dropdown {
-          margin-left: 0px;
+          margin-left: 0;
         }
       }
 
       a {
+        display: block;
+        padding-bottom: 8px;
         // make them stack nicely next to the bootstrap dropdown toggle
         padding-top: 8px;
-        padding-bottom: 8px;
-        display: block;
       }
-
-    }
-
-    .icon-thumbs-up {
 
     }
 
@@ -335,9 +353,8 @@ div.ccm-conversation-message {
 }
 
 div.ccm-conversation-messages-threaded {
-
   div.ccm-conversation-message-level0 {
-    margin-left: 0px;
+    margin-left: 0;
   }
 
   div.ccm-conversation-message-level1 {
@@ -363,8 +380,8 @@ div.ccm-conversation-form-submitted {
 }
 
 div.ccm-conversation-load-more-messages {
+  padding: 0 0 20px;
   text-align: center;
-  padding: 0px 0px 20px 0px;
 }
 
 /**
@@ -380,33 +397,33 @@ div.ccm-conversation-load-more-messages {
  */
 ul.ccm-discussion-topics {
   list-style-type: none;
-  margin: 0px 0px 20px 0px;
-  padding: 0px;
+  margin: 0 0 20px;
+  padding: 0;
 
   li {
+    border-bottom: 1px inset #ccc;
     display: block;
+    min-height: 60px;
     padding: 4px 4px 10px 80px;
     position: relative;
-    min-height: 60px;
-    border-bottom: 1px inset #ccc;
 
     div.ccm-discussion-topic-replies {
-      position: absolute;
-      top: 18px;
-      left: 0px;
-      height: 62px;
-      width: 62px;
-      text-align: center;
-
-      em {
-        font-style: normal;
-        display: block;
-        line-height: 1em;
-        color: #999;
-        margin: 5px auto 0px auto;
-      }
 
       color: #999;
+      height: 62px;
+      left: 0;
+      position: absolute;
+      text-align: center;
+      top: 18px;
+      width: 62px;
+
+      em {
+        color: #999;
+        display: block;
+        font-style: normal;
+        line-height: 1em;
+        margin: 5px auto 0;
+      }
 
     }
 

--- a/assets/documents/scss/frontend.scss
+++ b/assets/documents/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/documents/scss/frontend/_document-library.scss
+++ b/assets/documents/scss/frontend/_document-library.scss
@@ -1,56 +1,55 @@
-th.ccm-block-document-library-active-sort-desc a:after,
-th.ccm-block-document-library-active-sort-desc span:after {
-  border-width: 4px 4px 0px 4px;
+th.ccm-block-document-library-active-sort-desc a::after,
+th.ccm-block-document-library-active-sort-desc span::after {
+  border-color: #000 transparent transparent;
   border-style: solid;
-  border-color: #000 transparent transparent transparent;
-  vertical-align: middle;
-  content: "";
-  width: 0;
-  height: 0;
+  border-width: 4px 4px 0;
+  content: '';
   display: inline-block;
+  height: 0;
   margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
-th.ccm-block-document-library-active-sort-asc a:after,
-th.ccm-block-document-library-active-sort-asc span:after
-{
-  border-width: 0px 4px 4px 4px;
+th.ccm-block-document-library-active-sort-asc a::after,
+th.ccm-block-document-library-active-sort-asc span::after {
+  border-color: transparent transparent #000;
   border-style: solid;
-  border-color: transparent transparent #000 transparent;
-  vertical-align: middle;
-  content: "";
-  width: 0;
-  height: 0;
+  border-width: 0 4px 4px;
+  content: '';
   display: inline-block;
+  height: 0;
   margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
 table.ccm-block-document-library-table thead th.ccm-block-document-library-column-thumbnail {
   width: 1px;
 }
 
-a.ccm-block-document-library-details:after {
-  border-width: 0px 4px 4px 4px;
+a.ccm-block-document-library-details::after {
+  border-color: transparent transparent #000;
   border-style: solid;
-  border-color: transparent transparent #000 transparent;
-  vertical-align: middle;
-  content: "";
-  width: 0;
-  height: 0;
+  border-width: 0 4px 4px;
+  content: '';
   display: inline-block;
+  height: 0;
   margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
-a.ccm-block-document-library-details-open:after {
-  border-width: 4px 4px 0px 4px;
+a.ccm-block-document-library-details-open::after {
+  border-color: #000 transparent transparent;
   border-style: solid;
-  border-color: #000 transparent transparent transparent;
-  vertical-align: middle;
-  content: "";
-  width: 0;
-  height: 0;
+  border-width: 4px 4px 0;
+  content: '';
   display: inline-block;
+  height: 0;
   margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
 tr.ccm-block-document-library-table-expanded-properties {
@@ -63,31 +62,30 @@ a.ccm-block-document-library-add-files {
   margin-left: 20px;
 }
 
-a.ccm-block-document-library-advanced-search:after,
-a.ccm-block-document-library-add-files:after {
-  border-width: 0px 4px 4px 4px;
+a.ccm-block-document-library-advanced-search::after,
+a.ccm-block-document-library-add-files::after {
+  border-color: transparent transparent #000;
   border-style: solid;
-  border-color: transparent transparent #000 transparent;
-  vertical-align: middle;
-  content: "";
-  width: 0;
-  height: 0;
+  border-width: 0 4px 4px;
+  content: '';
   display: inline-block;
+  height: 0;
   margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
-a.ccm-block-document-library-advanced-search-open:after,
-a.ccm-block-document-library-add-files-open:after
-{
-  border-width: 4px 4px 0px 4px;
+a.ccm-block-document-library-advanced-search-open::after,
+a.ccm-block-document-library-add-files-open::after {
+  border-color: #000 transparent transparent;
   border-style: solid;
-  border-color: #000 transparent transparent transparent;
-  vertical-align: middle;
-  content: "";
-  width: 0;
-  height: 0;
+  border-width: 4px 4px 0;
+  content: '';
   display: inline-block;
+  height: 0;
   margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
 div.ccm-block-document-library-advanced-search-fields,
@@ -100,21 +98,21 @@ div.ccm-block-document-library-add-files-uploading {
 div.ccm-block-document-library-add-files-uploader {
   border: 1px solid #ccc;
   border-radius: 4px;
-  padding: 30px;
   color: #aaa;
   font-size: 1.5em;
-  text-align: center;
+  padding: 30px;
   position: relative;
+  text-align: center;
 }
 
 div.ccm-block-document-library-add-files-uploader input {
-  position: absolute;
-  opacity: 0;
-  top:  0px;
-  left: 0px;
-  width: 100%;
-  height: 100%;
   cursor: pointer;
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
 }
 
 a.ccm-block-document-library-icon {

--- a/assets/documents/scss/frontend/_frontend.scss
+++ b/assets/documents/scss/frontend/_frontend.scss
@@ -1,15 +1,15 @@
 // jQuery UI
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
-@import "../../../cms/scss/variables";
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins';
+@import '../../../cms/scss/variables';
 
-@import "~jquery-ui/themes/base/core.css";
-@import "~jquery-ui/themes/base/dialog.css";
-@import "../../../cms/scss/jquery-ui/theme";
-@import "../../../cms/scss/jquery-ui/overrides";
+@import '~jquery-ui/themes/base/core.css';
+@import '~jquery-ui/themes/base/dialog.css';
+@import '../../../cms/scss/jquery-ui/theme';
+@import '../../../cms/scss/jquery-ui/overrides';
 
-@import "../../../cms/scss/dialog";
-@import "../../../cms/scss/nprogress";
+@import '../../../cms/scss/dialog';
+@import '../../../cms/scss/nprogress';
 
 @import 'document-library';

--- a/assets/express/scss/frontend.scss
+++ b/assets/express/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/express/scss/frontend/_express-entry-list.scss
+++ b/assets/express/scss/frontend/_express-entry-list.scss
@@ -1,60 +1,60 @@
-.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-desc a:after,
-.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-desc span:after {
-    border-width: 4px 4px 0px 4px;
-    border-style: solid;
-    border-color: #000 transparent transparent transparent;
-    vertical-align: middle;
-    content: "";
-    width: 0;
-    height: 0;
-    display: inline-block;
-    margin-left: 10px;
- }
+.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-desc a::after,
+.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-desc span::after {
+  border-color: #000 transparent transparent;
+  border-style: solid;
+  border-width: 4px 4px 0;
+  content: '';
+  display: inline-block;
+  height: 0;
+  margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
+}
 
-.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-asc a:after,
-.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-asc span:after {
-    border-width: 0px 4px 4px 4px;
-    border-style: solid;
-    border-color: transparent transparent #000 transparent;
-    vertical-align: middle;
-    content: "";
-    width: 0;
-    height: 0;
-    display: inline-block;
-    margin-left: 10px;
- }
+.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-asc a::after,
+.ccm-block-express-entry-list-table th.ccm-results-list-active-sort-asc span::after {
+  border-color: transparent transparent #000;
+  border-style: solid;
+  border-width: 0 4px 4px;
+  content: '';
+  display: inline-block;
+  height: 0;
+  margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
+}
 
 
 
 a.ccm-block-express-entry-list-advanced-search {
-    margin-left: 20px;
-    white-space: nowrap;
+  margin-left: 20px;
+  white-space: nowrap;
 }
 
-a.ccm-block-express-entry-list-advanced-search:after {
-    border-width: 0px 4px 4px 4px;
-    border-style: solid;
-    border-color: transparent transparent #000 transparent;
-    vertical-align: middle;
-    content: "";
-    width: 0;
-    height: 0;
-    display: inline-block;
-    margin-left: 10px;
+a.ccm-block-express-entry-list-advanced-search::after {
+  border-color: transparent transparent #000;
+  border-style: solid;
+  border-width: 0 4px 4px;
+  content: '';
+  display: inline-block;
+  height: 0;
+  margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
-a.ccm-block-express-entry-list-advanced-search-open:after {
-    border-width: 4px 4px 0px 4px;
-    border-style: solid;
-    border-color: #000 transparent transparent transparent;
-    vertical-align: middle;
-    content: "";
-    width: 0;
-    height: 0;
-    display: inline-block;
-    margin-left: 10px;
+a.ccm-block-express-entry-list-advanced-search-open::after {
+  border-color: #000 transparent transparent;
+  border-style: solid;
+  border-width: 4px 4px 0;
+  content: '';
+  display: inline-block;
+  height: 0;
+  margin-left: 10px;
+  vertical-align: middle;
+  width: 0;
 }
 
 div.ccm-block-express-entry-list-advanced-search-fields {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }

--- a/assets/express/scss/frontend/_frontend.scss
+++ b/assets/express/scss/frontend/_frontend.scss
@@ -1,1 +1,1 @@
-@import "express-entry-list";
+@import 'express-entry-list';

--- a/assets/faq/scss/frontend.scss
+++ b/assets/faq/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/faq/scss/frontend/_frontend.scss
+++ b/assets/faq/scss/frontend/_frontend.scss
@@ -1,2 +1,2 @@
 // FAQ Block
-@import "faq/faq";
+@import 'faq/faq';

--- a/assets/faq/scss/frontend/faq/_faq.scss
+++ b/assets/faq/scss/frontend/faq/_faq.scss
@@ -1,12 +1,12 @@
 div.ccm-faq-block-links {
-    margin-bottom: 50px;
+  margin-bottom: 50px;
 }
 
 div.ccm-faq-block-links a {
-    display: block;
-    margin-bottom: 10px;
+  display: block;
+  margin-bottom: 10px;
 }
 
 div.ccm-faq-entry-content {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }

--- a/assets/imagery/scss/frontend.scss
+++ b/assets/imagery/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/imagery/scss/frontend/_frontend.scss
+++ b/assets/imagery/scss/frontend/_frontend.scss
@@ -1,6 +1,6 @@
 // Lightbox
-@import "lightbox/lightbox";
+@import 'lightbox/lightbox';
 
 // Image Slider Block
-@import "responsive-slides";
-@import "image-slider/image-slider";
+@import 'responsive-slides';
+@import 'image-slider/image-slider';

--- a/assets/imagery/scss/frontend/_responsive-slides.scss
+++ b/assets/imagery/scss/frontend/_responsive-slides.scss
@@ -1,59 +1,61 @@
+/* stylelint-disable selector-class-pattern */
 /*! http://responsiveslides.com v1.55 by @viljamis */
 .rslides {
-  position: relative;
   list-style: none;
-  overflow: hidden;
-  width: 100%;
-  padding: 0;
   margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
+  width: 100%;
 }
 
 .rslides > li {
-  -webkit-backface-visibility: hidden;
-  position: absolute;
+  backface-visibility: hidden;
   display: none;
-  width: 100%;
   left: 0;
+  position: absolute;
   top: 0;
+  width: 100%;
 }
 
 .rslides > li:first-child {
-  position: relative;
   display: block;
   float: left;
+  position: relative;
 }
 
 .rslides img {
-  display: block;
-  height: auto;
-  float: left;
-  width: 100%;
   border: 0;
+  display: block;
+  float: left;
+  height: auto;
+  width: 100%;
 }
 
 .rslides_nav {
-  position: absolute;
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-  top: 50%;
+  background: transparent url('../images/responsive-slides/arrows.gif') no-repeat left top;
+  height: 61px;
   left: 0;
-  z-index: 99;
+  margin-top: -45px;
   opacity: 0.7;
   overflow: hidden;
+  position: absolute;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   text-decoration: none;
-  height: 61px;
+  top: 50%;
   width: 38px;
-  background: transparent url("../images/responsive-slides/arrows.gif") no-repeat left top;
-  margin-top: -45px;
+  z-index: 99;
 }
 
 .rslides_tabs {
-  padding-left: 0px;
-  padding-top: 15px;
   padding-bottom: 10px;
+  padding-left: 0;
+  padding-top: 15px;
 }
+
 .rslides_tabs li {
-  list-style-type: none;
   display: inline-block;
+  list-style-type: none;
   margin-right: 5px;
 }
 
@@ -62,20 +64,18 @@
 }
 
 .rslides_tabs li a {
-  text-indent: -9999px;
-  overflow: hidden;
   background: #ccccc9;
-  width: 15px;
-  height: 15px;
-  display: inline-block;
-  margin-right: 10px;
-  -webkit-border-radius: 30px;
-  -moz-border-radius: 30px;
   border-radius: 30px;
+  display: inline-block;
+  height: 15px;
+  margin-right: 10px;
+  overflow: hidden;
+  text-indent: -9999px;
+  width: 15px;
 }
 
 .rslides_nav.next {
-  left: auto;
   background-position: right top;
+  left: auto;
   right: 0;
 }

--- a/assets/imagery/scss/frontend/image-slider/_image-slider.scss
+++ b/assets/imagery/scss/frontend/image-slider/_image-slider.scss
@@ -5,22 +5,22 @@
 }
 
 .ccm-image-slider-text {
-  position: absolute;
-  width: 45%;
   left: 0;
+  position: absolute;
   top: 10%;
+  width: 45%;
 }
 
 .ccm-image-slider-title {
-  margin-top:auto;
+  margin-top: auto;
 }
 
 .ccm-image-slider-container a.mega-link-overlay {
-  position: absolute;
-  z-index: 20;
-  width: 100%;
   height: 100%;
-  left: 0px;
+  left: 0;
+  position: absolute;
+  width: 100%;
+  z-index: 20;
 }
 
 .rslides {

--- a/assets/imagery/scss/frontend/lightbox/_effects.scss
+++ b/assets/imagery/scss/frontend/lightbox/_effects.scss
@@ -2,8 +2,8 @@
   /* start state */
   .mfp-with-anim {
     opacity: 0;
-    transition: all 0.2s ease-in-out;
     transform: scale(0.8);
+    transition: all 0.2s ease-in-out;
   }
 
   &.mfp-bg {
@@ -17,6 +17,7 @@
       opacity: 1;
       transform: scale(1);
     }
+
     &.mfp-bg {
       opacity: 0.8;
     }
@@ -24,11 +25,11 @@
 
   /* animate out */
   &.mfp-removing {
-
     .mfp-with-anim {
-      transform: scale(0.8);
       opacity: 0;
+      transform: scale(0.8);
     }
+
     &.mfp-bg {
       opacity: 0;
     }
@@ -41,9 +42,6 @@
 /* overlay at start */
 .mfp-fade.mfp-bg {
   opacity: 0;
-
-  -webkit-transition: all 0.15s ease-out;
-  -moz-transition: all 0.15s ease-out;
   transition: all 0.15s ease-out;
 }
 /* overlay animate in */
@@ -58,9 +56,6 @@
 /* content at start */
 .mfp-fade.mfp-wrap .mfp-content {
   opacity: 0;
-
-  -webkit-transition: all 0.15s ease-out;
-  -moz-transition: all 0.15s ease-out;
   transition: all 0.15s ease-out;
 }
 /* content animate it */

--- a/assets/imagery/scss/frontend/lightbox/_lightbox.scss
+++ b/assets/imagery/scss/frontend/lightbox/_lightbox.scss
@@ -1,16 +1,16 @@
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "../../../../cms/scss/variables";
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '../../../../cms/scss/variables';
 
-@import "magnific-popup";
+@import 'magnific-popup';
 
 div.ccm-lightbox-popup-white {
+  background-color: white;
+  border-radius: 10px;
+  margin: 0 auto;
 
   max-width: 600px;
-  background-color: white;
   padding: 20px 60px 20px 20px;
-  margin: 0px auto 0px auto;
   position: relative;
-  border-radius: 10px;
   
 }

--- a/assets/imagery/scss/frontend/lightbox/_magnific-popup.scss
+++ b/assets/imagery/scss/frontend/lightbox/_magnific-popup.scss
@@ -1,66 +1,68 @@
+/* stylelint-disable selector-class-pattern, value-no-vendor-prefix, property-no-vendor-prefix */
 /* Magnific Popup CSS */
 
-@import "effects.scss";
+@import 'effects';
 
 
 .mfp-bg {
-  top: 0;
-  left: 0;
-  width: 100%;
+  background: #0b0b0b;
+  filter: alpha(opacity=80);
   height: 100%;
-  z-index: $lightbox-overlay;
+  left: 0;
+  opacity: 0.8;
   overflow: hidden;
   position: fixed;
-  background: #0b0b0b;
-  opacity: 0.8;
-  filter: alpha(opacity=80); }
+  top: 0;
+  width: 100%;
+  z-index: $lightbox-overlay; }
 
 .mfp-wrap {
-  top: 0;
-  left: 0;
-  width: 100%;
+  -webkit-backface-visibility: hidden;
   height: 100%;
-  z-index: $lightbox-overlay-wrap;
-  position: fixed;
+  left: 0;
   outline: none !important;
-  -webkit-backface-visibility: hidden; }
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: $lightbox-overlay-wrap; }
 
 .mfp-container {
-  text-align: center;
-  position: absolute;
-  width: 100%;
+  box-sizing: border-box;
   height: 100%;
   left: 0;
-  top: 0;
   padding: 0 8px;
-  box-sizing: border-box; }
+  position: absolute;
+  text-align: center;
+  top: 0;
+  width: 100%; }
 
-.mfp-container:before {
+.mfp-container::before {
   content: '';
   display: inline-block;
   height: 100%;
   vertical-align: middle; }
 
-.mfp-align-top .mfp-container:before {
+.mfp-align-top .mfp-container::before {
   display: none; }
 
 .mfp-content {
-  position: relative;
   display: inline-block;
-  vertical-align: middle;
   margin: 0 auto;
+  position: relative;
   text-align: left;
+  vertical-align: middle;
   z-index: $lightbox-content; }
 
 .mfp-inline-holder .mfp-content,
 .mfp-ajax-holder .mfp-content {
-  width: 100%;
-  cursor: auto; }
+  cursor: auto;
+  width: 100%; }
 
 .mfp-ajax-cur {
   cursor: progress; }
 
-.mfp-zoom-out-cur, .mfp-zoom-out-cur .mfp-image-holder .mfp-close {
+.mfp-zoom-out-cur,
+.mfp-zoom-out-cur .mfp-image-holder .mfp-close {
   cursor: -moz-zoom-out;
   cursor: -webkit-zoom-out;
   cursor: zoom-out; }
@@ -89,19 +91,21 @@
   display: none !important; }
 
 .mfp-preloader {
-  color: #CCC;
+  color: #ccc;
+  left: 8px;
+  margin-top: -0.8em;
   position: absolute;
+  right: 8px;
+  text-align: center;
   top: 50%;
   width: auto;
-  text-align: center;
-  margin-top: -0.8em;
-  left: 8px;
-  right: 8px;
   z-index: $lightbox-loader; }
-  .mfp-preloader a {
-    color: #CCC; }
-    .mfp-preloader a:hover {
-      color: #FFF; }
+
+.mfp-preloader a {
+  color: #ccc; }
+
+.mfp-preloader a:hover {
+  color: #fff; }
 
 .mfp-s-ready .mfp-preloader {
   display: none; }
@@ -111,190 +115,207 @@
 
 button.mfp-close,
 button.mfp-arrow {
-  overflow: visible;
-  cursor: pointer;
+  -webkit-appearance: none;
   background: transparent;
   border: 0;
-  -webkit-appearance: none;
+  box-shadow: none;
+  cursor: pointer;
   display: block;
   outline: none;
+  overflow: visible;
   padding: 0;
-  z-index: $lightbox-arrows;
-  box-shadow: none;
-  touch-action: manipulation; }
+  touch-action: manipulation;
+  z-index: $lightbox-arrows; }
 
 button::-moz-focus-inner {
-  padding: 0;
-  border: 0; }
+  border: 0;
+  padding: 0; }
 
 .mfp-close {
-  width: 44px;
+  color: #fff;
+  font-family: Arial, Baskerville, monospace;
+  font-size: 28px;
+  font-style: normal;
   height: 44px;
   line-height: 44px;
-  position: absolute;
-  right: 0;
-  top: 0;
-  text-decoration: none;
-  text-align: center;
   opacity: 0.65;
   padding: 0 0 18px 10px;
-  color: #FFF;
-  font-style: normal;
-  font-size: 28px;
-  font-family: Arial, Baskerville, monospace; }
-  .mfp-close:hover,
-  .mfp-close:focus {
-    opacity: 1; }
-  .mfp-close:active {
-    top: 1px; }
+  position: absolute;
+  right: 0;
+  text-align: center;
+  text-decoration: none;
+  top: 0;
+  width: 44px; }
+
+.mfp-close:hover,
+.mfp-close:focus {
+  opacity: 1; }
+
+.mfp-close:active {
+  top: 1px; }
 
 .mfp-close-btn-in .mfp-close {
   color: #333; }
 
 .mfp-image-holder .mfp-close,
 .mfp-iframe-holder .mfp-close {
-  color: #FFF;
+  color: #fff;
+  padding-right: 6px;
   right: -6px;
   text-align: right;
-  padding-right: 6px;
   width: 100%; }
 
 .mfp-counter {
-  position: absolute;
-  top: 0;
-  right: 0;
-  color: #CCC;
+  color: #ccc;
   font-size: 12px;
   line-height: 18px;
+  position: absolute;
+  right: 0;
+  top: 0;
   white-space: nowrap; }
 
 .mfp-arrow {
-  position: absolute;
-  opacity: 0.65;
-  margin: 0;
-  top: 50%;
-  margin-top: -55px;
-  padding: 0;
-  width: 90px;
   height: 110px;
-  -webkit-tap-highlight-color: transparent; }
-  .mfp-arrow:active {
-    margin-top: -54px; }
-  .mfp-arrow:hover,
-  .mfp-arrow:focus {
-    opacity: 1; }
-  .mfp-arrow:before,
-  .mfp-arrow:after {
-    content: '';
-    display: block;
-    width: 0;
-    height: 0;
-    position: absolute;
-    left: 0;
-    top: 0;
-    margin-top: 35px;
-    margin-left: 35px;
-    border: medium inset transparent; }
-  .mfp-arrow:after {
-    border-top-width: 13px;
-    border-bottom-width: 13px;
-    top: 8px; }
-  .mfp-arrow:before {
-    border-top-width: 21px;
-    border-bottom-width: 21px;
-    opacity: 0.7; }
+  margin: 0;
+  margin-top: -55px;
+  opacity: 0.65;
+  padding: 0;
+  position: absolute;
+  -webkit-tap-highlight-color: transparent;
+  top: 50%;
+  width: 90px; }
+
+.mfp-arrow:active {
+  margin-top: -54px; }
+
+.mfp-arrow:hover,
+.mfp-arrow:focus {
+  opacity: 1; }
+
+.mfp-arrow::before,
+.mfp-arrow::after {
+  border: medium inset transparent;
+  content: '';
+  display: block;
+  height: 0;
+  left: 0;
+  margin-left: 35px;
+  margin-top: 35px;
+  position: absolute;
+  top: 0;
+  width: 0; }
+
+.mfp-arrow::after {
+  border-bottom-width: 13px;
+  border-top-width: 13px;
+  top: 8px; }
+
+.mfp-arrow::before {
+  border-bottom-width: 21px;
+  border-top-width: 21px;
+  opacity: 0.7; }
 
 .mfp-arrow-left {
   left: 0; }
-  .mfp-arrow-left:after {
-    border-right: 17px solid #FFF;
-    margin-left: 31px; }
-  .mfp-arrow-left:before {
-    margin-left: 25px;
-    border-right: 27px solid #3F3F3F; }
+
+.mfp-arrow-left::after {
+  border-right: 17px solid #fff;
+  margin-left: 31px; }
+
+.mfp-arrow-left::before {
+  border-right: 27px solid #3f3f3f;
+  margin-left: 25px; }
 
 .mfp-arrow-right {
   right: 0; }
-  .mfp-arrow-right:after {
-    border-left: 17px solid #FFF;
-    margin-left: 39px; }
-  .mfp-arrow-right:before {
-    border-left: 27px solid #3F3F3F; }
+
+.mfp-arrow-right::after {
+  border-left: 17px solid #fff;
+  margin-left: 39px; }
+
+.mfp-arrow-right::before {
+  border-left: 27px solid #3f3f3f; }
 
 .mfp-iframe-holder {
-  padding-top: 40px;
-  padding-bottom: 40px; }
-  .mfp-iframe-holder .mfp-content {
-    line-height: 0;
-    width: 100%;
-    max-width: 900px; }
-  .mfp-iframe-holder .mfp-close {
-    top: -40px; }
+  padding-bottom: 40px;
+  padding-top: 40px; }
+
+.mfp-iframe-holder .mfp-content {
+  line-height: 0;
+  max-width: 900px;
+  width: 100%; }
+
+.mfp-iframe-holder .mfp-close {
+  top: -40px; }
 
 .mfp-iframe-scaler {
-  width: 100%;
   height: 0;
   overflow: hidden;
-  padding-top: 56.25%; }
-  .mfp-iframe-scaler iframe {
-    position: absolute;
-    display: block;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
-    background: #000; }
+  padding-top: 56.25%;
+  width: 100%; }
+
+.mfp-iframe-scaler iframe {
+  background: #000;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+  display: block;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%; }
 
 /* Main image in popup */
 img.mfp-img {
-  width: auto;
-  max-width: 100%;
-  height: auto;
-  display: block;
-  line-height: 0;
   box-sizing: border-box;
-  padding: 40px 0 40px;
-  margin: 0 auto; }
+  display: block;
+  height: auto;
+  line-height: 0;
+  margin: 0 auto;
+  max-width: 100%;
+  padding: 40px 0;
+  width: auto; }
 
 /* The shadow behind the image */
 .mfp-figure {
   line-height: 0; }
-  .mfp-figure:after {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 40px;
-    bottom: 40px;
-    display: block;
-    right: 0;
-    width: auto;
-    height: auto;
-    z-index: -1;
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
-    background: #444; }
-  .mfp-figure small {
-    color: #BDBDBD;
-    display: block;
-    font-size: 12px;
-    line-height: 14px; }
-  .mfp-figure figure {
-    margin: 0; }
+
+.mfp-figure::after {
+  background: #444;
+  bottom: 40px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+  content: '';
+  display: block;
+  height: auto;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 40px;
+  width: auto;
+  z-index: -1; }
+
+.mfp-figure small {
+  color: #bdbdbd;
+  display: block;
+  font-size: 12px;
+  line-height: 14px; }
+
+.mfp-figure figure {
+  margin: 0; }
 
 .mfp-bottom-bar {
+  cursor: auto;
+  left: 0;
   margin-top: -36px;
   position: absolute;
   top: 100%;
-  left: 0;
-  width: 100%;
-  cursor: auto; }
+  width: 100%; }
 
 .mfp-title {
-  text-align: left;
+  color: #f3f3f3;
   line-height: 18px;
-  color: #F3F3F3;
-  word-wrap: break-word;
-  padding-right: 36px; }
+  padding-right: 36px;
+  text-align: left;
+  word-wrap: break-word; }
 
 .mfp-image-holder .mfp-content {
   max-width: 100%; }
@@ -309,48 +330,58 @@ img.mfp-img {
   .mfp-img-mobile .mfp-image-holder {
     padding-left: 0;
     padding-right: 0; }
+
   .mfp-img-mobile img.mfp-img {
     padding: 0; }
-  .mfp-img-mobile .mfp-figure:after {
-    top: 0;
-    bottom: 0; }
+
+  .mfp-img-mobile .mfp-figure::after {
+    bottom: 0;
+    top: 0; }
+
   .mfp-img-mobile .mfp-figure small {
     display: inline;
     margin-left: 5px; }
+
   .mfp-img-mobile .mfp-bottom-bar {
     background: rgba(0, 0, 0, 0.6);
     bottom: 0;
+    box-sizing: border-box;
     margin: 0;
-    top: auto;
     padding: 3px 5px;
     position: fixed;
-    box-sizing: border-box; }
-    .mfp-img-mobile .mfp-bottom-bar:empty {
-      padding: 0; }
+    top: auto; }
+
+  .mfp-img-mobile .mfp-bottom-bar:empty {
+    padding: 0; }
+
   .mfp-img-mobile .mfp-counter {
     right: 5px;
     top: 3px; }
+
   .mfp-img-mobile .mfp-close {
-    top: 0;
-    right: 0;
-    width: 35px;
+    background: rgba(0, 0, 0, 0.6);
     height: 35px;
     line-height: 35px;
-    background: rgba(0, 0, 0, 0.6);
+    padding: 0;
     position: fixed;
+    right: 0;
     text-align: center;
-    padding: 0; } }
+    top: 0;
+    width: 35px; } }
 
 @media all and (max-width: 900px) {
   .mfp-arrow {
     -webkit-transform: scale(0.75);
     transform: scale(0.75); }
+
   .mfp-arrow-left {
     -webkit-transform-origin: 0;
     transform-origin: 0; }
+
   .mfp-arrow-right {
     -webkit-transform-origin: 100%;
     transform-origin: 100%; }
+
   .mfp-container {
     padding-left: 6px;
     padding-right: 6px; } }

--- a/assets/maps/scss/frontend.scss
+++ b/assets/maps/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/maps/scss/frontend/_frontend.scss
+++ b/assets/maps/scss/frontend/_frontend.scss
@@ -1,1 +1,1 @@
-@import "google-map";
+@import 'google-map';

--- a/assets/maps/scss/frontend/_google-map.scss
+++ b/assets/maps/scss/frontend/_google-map.scss
@@ -1,7 +1,8 @@
+/* stylelint-disable selector-class-pattern */
 .googleMapCanvas {
-  width: 100%;
   border: 0 none;
   height: 400px;
+  width: 100%;
 }
 
 .googleMapCanvas img {

--- a/assets/multilingual/scss/frontend.scss
+++ b/assets/multilingual/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/multilingual/scss/frontend/_frontend.scss
+++ b/assets/multilingual/scss/frontend/_frontend.scss
@@ -1,2 +1,2 @@
 // Core block types
-@import "switch-language-flags";
+@import 'switch-language-flags';

--- a/assets/multilingual/scss/frontend/_switch-language-flags.scss
+++ b/assets/multilingual/scss/frontend/_switch-language-flags.scss
@@ -1,18 +1,18 @@
 div.ccm-block-switch-language-flags {
-    display: inline-block;
+  display: inline-block;
 }
 
 div.ccm-block-switch-language-flags-label {
-    float: left;
-    margin-right: 8px
+  float: left;
+  margin-right: 8px;
 }
 
 div.ccm-block-switch-language-flags a {
-    margin: 2px;
-    float: left;
-    opacity: 0.4;
+  float: left;
+  margin: 2px;
+  opacity: 0.4;
 }
 
 div.ccm-block-switch-language-flags a.ccm-block-switch-language-active-flag {
-    opacity: 1.0;
+  opacity: 1;
 }

--- a/assets/navigation/scss/frontend.scss
+++ b/assets/navigation/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/navigation/scss/frontend/_date-navigation.scss
+++ b/assets/navigation/scss/frontend/_date-navigation.scss
@@ -1,7 +1,7 @@
 ul.ccm-block-date-navigation-dates {
   list-style-type: none;
-  padding-left: 0px;
-  padding-bottom: 0px;
+  padding-bottom: 0;
+  padding-left: 0;
 }
 
 .ccm-block-date-navigation-date-selected {

--- a/assets/navigation/scss/frontend/_frontend.scss
+++ b/assets/navigation/scss/frontend/_frontend.scss
@@ -1,5 +1,5 @@
 // Core block types
-@import "page-list";
-@import "rss-displayer";
-@import "date-navigation";
-@import "responsive-navigation";
+@import 'page-list';
+@import 'rss-displayer';
+@import 'date-navigation';
+@import 'responsive-navigation';

--- a/assets/navigation/scss/frontend/_page-list.scss
+++ b/assets/navigation/scss/frontend/_page-list.scss
@@ -1,7 +1,7 @@
 a.ccm-block-page-list-rss-feed {
   position: absolute;
-  top: 0;
   right: 0;
+  top: 0;
 }
 
 div.ccm-block-page-list-wrapper {
@@ -26,8 +26,8 @@ div.ccm-block-page-list-page-entry-horizontal div.ccm-block-page-list-page-entry
 }
 
 div.ccm-block-page-list-page-entry-horizontal div.ccm-block-page-list-page-entry-thumbnail img {
-  width: 120px;
   max-width: none;
+  width: 120px;
 }
 
 

--- a/assets/navigation/scss/frontend/_responsive-navigation.scss
+++ b/assets/navigation/scss/frontend/_responsive-navigation.scss
@@ -1,3 +1,3 @@
 .ccm-responsive-overlay {
-    display: none;
+  display: none;
 }

--- a/assets/navigation/scss/frontend/_rss-displayer.scss
+++ b/assets/navigation/scss/frontend/_rss-displayer.scss
@@ -1,11 +1,11 @@
 .ccm-block-rss-displayer-item {
-    margin-bottom: 16px;
+  margin-bottom: 16px;
 }
 
 .ccm-block-rss-displayer-item-title {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .ccm-block-rss-displayer-item-date {
-    color: #999;
+  color: #999;
 }

--- a/assets/polls/scss/frontend.scss
+++ b/assets/polls/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/polls/scss/frontend/_frontend.scss
+++ b/assets/polls/scss/frontend/_frontend.scss
@@ -1,2 +1,2 @@
 // Core block types
-@import "survey";
+@import 'survey';

--- a/assets/polls/scss/frontend/_survey.scss
+++ b/assets/polls/scss/frontend/_survey.scss
@@ -1,11 +1,12 @@
+/* stylelint-disable selector-class-pattern */
 #surveyResults .surveySwatch {
-  background: #999999 none repeat scroll 0%;
-  border: 1px solid #666666;
+  background: #999 none repeat scroll 0%;
+  border: 1px solid #666;
   float: left;
   font-size: 1px;
   height: 10px;
   line-height: 1px;
-  margin: 5px 4px 0px 0px;
+  margin: 5px 4px 0 0;
   width: 10px;
 }
 

--- a/assets/search/scss/frontend.scss
+++ b/assets/search/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/search/scss/frontend/_frontend.scss
+++ b/assets/search/scss/frontend/_frontend.scss
@@ -1,2 +1,2 @@
-@import "search-block";
-@import "search-block-tag-cloud";
+@import 'search-block';
+@import 'search-block-tag-cloud';

--- a/assets/search/scss/frontend/_search-block-tag-cloud.scss
+++ b/assets/search/scss/frontend/_search-block-tag-cloud.scss
@@ -5,26 +5,24 @@ ul.ccm-search-block-tag-cloud {
 }
 
 ul.ccm-search-block-tag-cloud li {
+  color: #ccc;
+  display: inline-block;
+  font-size: 10px;
   margin: 0;
+  margin-bottom: 8px;
+  margin-right: 8px;
   padding: 0;
   zoom: 1;
-  display: inline-block;
-  margin-right: 8px;
-  margin-bottom: 8px;
-  color: #ccc;
-  font-size: 10px;
 }
 
 ul.ccm-search-block-tag-cloud li a {
-  padding: 4px;
   background-color: #f6f6f6;
+  border: 1px solid #aaa;
+  border-radius: 4px;
   display: inline-block;
+  padding: 4px;
   text-decoration: none;
   vertical-align: middle;
-  border: 1px solid #aaa;
-  -moz-border-radius: 4px;
-  -webkit-border-radius: 4px;
-  border-radius: 4px;
 }
 
 ul.ccm-search-block-tag-cloud li a:hover {
@@ -34,16 +32,16 @@ ul.ccm-search-block-tag-cloud li a:hover {
 
 ul.ccm-search-block-tag-cloud li {
   float: left;
-  margin-right: 20px;
-  white-space: nowrap;
-  padding: 0;
   margin-left: 0;
+  margin-right: 20px;
+  padding: 0;
+  white-space: nowrap;
 }
 
 ul.ccm-search-block-tag-cloud li {
   float: left;
-  margin-right: 20px;
-  white-space: nowrap;
-  padding: 0;
   margin-left: 0;
+  margin-right: 20px;
+  padding: 0;
+  white-space: nowrap;
 }

--- a/assets/search/scss/frontend/_search-block.scss
+++ b/assets/search/scss/frontend/_search-block.scss
@@ -1,9 +1,10 @@
+/* stylelint-disable selector-class-pattern */
 #searchResults .pageLink {
-  font-size: 12px;
   color: #999;
-  margin: 2px 0 8px 0;
-  padding: 0;
   display: block;
+  font-size: 12px;
+  margin: 2px 0 8px;
+  padding: 0;
 }
 
 #searchResults .searchResult {

--- a/assets/social/scss/frontend.scss
+++ b/assets/social/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/social/scss/frontend/_frontend.scss
+++ b/assets/social/scss/frontend/_frontend.scss
@@ -1,3 +1,3 @@
 // Core block types
-@import "share-this-page";
-@import "social-links";
+@import 'share-this-page';
+@import 'social-links';

--- a/assets/social/scss/frontend/_share-this-page.scss
+++ b/assets/social/scss/frontend/_share-this-page.scss
@@ -1,12 +1,12 @@
 .ccm-block-share-this-page ul.list-inline {
   display: inline-block;
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
 }
 
 .ccm-block-share-this-page ul.list-inline li {
-  padding: 0px;
+  display: inline-block;
   list-style-type: none;
   margin-right: 10px;
-  display: inline-block;
+  padding: 0;
 }

--- a/assets/social/scss/frontend/_social-links.scss
+++ b/assets/social/scss/frontend/_social-links.scss
@@ -1,12 +1,12 @@
 .ccm-block-social-links ul.list-inline {
   display: inline-block;
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
 }
 
 .ccm-block-social-links ul.list-inline li {
-  padding: 0px;
+  display: inline-block;
   list-style-type: none;
   margin-right: 10px;
-  display: inline-block;
+  padding: 0;
 }

--- a/assets/taxonomy/scss/frontend.scss
+++ b/assets/taxonomy/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/taxonomy/scss/frontend/_frontend.scss
+++ b/assets/taxonomy/scss/frontend/_frontend.scss
@@ -1,2 +1,2 @@
-@import "tags";
-@import "topic_list";
+@import 'tags';
+@import 'topic_list';

--- a/assets/taxonomy/scss/frontend/_tags.scss
+++ b/assets/taxonomy/scss/frontend/_tags.scss
@@ -1,12 +1,14 @@
+/* stylelint-disable property-no-vendor-prefix */
+
 .ccm-block-tags-wrapper .ccm-block-tags-tag {
-  display: inline-block;
-  color: #333;
-  padding: 5px 8px 6px 8px;
-  margin: 3px 6px 3px 0;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
   background-color: #eee;
+  border-radius: 4px;
+  border-radius: 4px;
+  border-radius: 4px;
+  color: #333;
+  display: inline-block;
+  margin: 3px 6px 3px 0;
+  padding: 5px 8px 6px;
 }
 
 .ccm-block-tags-wrapper a:hover .ccm-block-tags-tag {

--- a/assets/testimonials/scss/frontend.scss
+++ b/assets/testimonials/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/testimonials/scss/frontend/_frontend.scss
+++ b/assets/testimonials/scss/frontend/_frontend.scss
@@ -1,1 +1,1 @@
-@import "testimonial";
+@import 'testimonial';

--- a/assets/testimonials/scss/frontend/_testimonial.scss
+++ b/assets/testimonials/scss/frontend/_testimonial.scss
@@ -1,10 +1,10 @@
-div.ccm-block-testimonial-wrapper:before,
-div.ccm-block-testimonial-wrapper:after {
-  content: " "; // 1
+div.ccm-block-testimonial-wrapper::before,
+div.ccm-block-testimonial-wrapper::after {
+  content: ' '; // 1
   display: table; // 2
 }
 
-div.ccm-block-testimonial-wrapper:after {
+div.ccm-block-testimonial-wrapper::after {
   clear: both;
 }
 
@@ -14,13 +14,13 @@ div.ccm-block-testimonial-wrapper {
 
 div.ccm-block-testimonial-image {
   float: left;
-  margin-right: 20px;
   margin-bottom: 20px;
+  margin-right: 20px;
 }
 
 div.ccm-block-testimonial-image img {
-  max-width: 80px;
   max-height: 80px;
+  max-width: 80px;
 }
 
 div.ccm-block-testimonial-name {

--- a/assets/video/scss/frontend.scss
+++ b/assets/video/scss/frontend.scss
@@ -1,4 +1,4 @@
 // This is an entry point so it just includes the partial that includes everything else.
 // That way if we want to include full support in our theme we just include the partial (rather
 // than including the entry point because I think it's bad practice.)
-@import "frontend/frontend";
+@import 'frontend/frontend';

--- a/assets/video/scss/frontend/_frontend.scss
+++ b/assets/video/scss/frontend/_frontend.scss
@@ -1,1 +1,1 @@
-@import "youtube";
+@import 'youtube';

--- a/assets/video/scss/frontend/_youtube.scss
+++ b/assets/video/scss/frontend/_youtube.scss
@@ -1,30 +1,34 @@
-.youtubeBlockResponsive16by9,.youtubeBlockResponsive4by3 {
-  position: relative;
+/* stylelint-disable selector-class-pattern */
+.youtubeBlockResponsive16by9,
+.youtubeBlockResponsive4by3 {
   height: 0;
+  position: relative;
 }
-.youtubeBlockResponsive16by9 iframe, .youtubeBlockResponsive4by3 iframe{
+
+.youtubeBlockResponsive16by9 iframe,
+.youtubeBlockResponsive4by3 iframe {
+  border: 'none';
+  height: 100%;
+  left: 0;
   position: absolute;
   top: 0;
-  left: 0;
   width: 100%;
-  height: 100%;
-  border: none;
 }
 
 .youtubeBlockResponsive16by9 {
-  padding-bottom: 56.25%
+  padding-bottom: 56.25%;
 }
 
-.youtubeBlockResponsive4by3{
+.youtubeBlockResponsive4by3 {
   padding-bottom: 75%;
 }
 
-.ccm-edit-mode-disabled-item.youtubeBlockResponsive16by9  {
+.ccm-edit-mode-disabled-item.youtubeBlockResponsive16by9 {
+  padding-bottom: 28.125%;
   padding-top: 28.125%;
-  padding-bottom:  28.125%
 }
 
-.ccm-edit-mode-disabled-item.youtubeBlockResponsive4by3  {
+.ccm-edit-mode-disabled-item.youtubeBlockResponsive4by3 {
+  padding-bottom: 37.5%;
   padding-top: 37.5%;
-  padding-bottom: 37.5%
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,257 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/core": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+      "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.9.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+      "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+      "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/types": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@fortawesome/fontawesome-free": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz",
@@ -93,10 +344,131 @@
       "resolved": "https://registry.npmjs.org/@interactjs/utils/-/utils-1.8.4.tgz",
       "integrity": "sha512-Kg/da0pQSIvEChGL96fYOSzguDc+2zbz061BWnnskq2viZvPnacFIDC2Z+dEZHH+DBMnnLAt2pqLEulxauSQhA=="
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
+      "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@types/vfile": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/unist": "*",
+        "@types/vfile-message": "*"
+      }
+    },
+    "@types/vfile-message": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
+      "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
+      "dev": true,
+      "requires": {
+        "vfile-message": "*"
+      }
+    },
+    "ajv": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "ansicolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -116,7 +488,14 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -131,6 +510,21 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "optional": true
+    },
+    "autoprefixer": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.5.tgz",
+      "integrity": "sha512-URo6Zvt7VYifomeAfJlMFnYDhow1rk2bufwkbamPEAtQFcL11moLk4PnR7n9vlu7M+BkXAZkHFA0mIcY7tjQFg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.11.0",
+        "caniuse-lite": "^1.0.30001036",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.27",
+        "postcss-value-parser": "^4.0.3"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -148,6 +542,18 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/backstretch/-/backstretch-1.2.2.tgz",
       "integrity": "sha1-3fWmMhNBsuo/rzpj1+SEn9teoks="
+    },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -211,6 +617,66 @@
       "resolved": "https://registry.npmjs.org/bootstrap-tourist/-/bootstrap-tourist-0.2.1.tgz",
       "integrity": "sha512-qIJBrS64Lj/4Cz/yWaRCrKT82R0hLkH5W3T8Kyyu1eRlEUHt4DygiJqH4YDuwc2CsTZagpikxr7sUXu1X1Cn6w=="
     },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+      "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001038",
+        "electron-to-chromium": "^1.3.390",
+        "node-releases": "^1.1.53",
+        "pkg-up": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001038",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+      "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ==",
+      "dev": true
+    },
     "cardinal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
@@ -226,17 +692,115 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "optional": true
     },
+    "ccount": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true
+    },
     "ckeditor4": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.13.1.tgz",
       "integrity": "sha512-Fslq8yT9YtbIWAnexnW8cTl/fK6QiAbSaimq/iZWS/FAqSyVEJk72+fA4BczCUMx7aj/Wari0vZ8nE1L5akYCQ=="
     },
+    "clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^2.0.0"
+      }
+    },
+    "collapse-white-space": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
       }
     },
     "core-util-is": {
@@ -244,6 +808,25 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "optional": true
+    },
+    "cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      }
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
     },
     "csv-parse": {
       "version": "4.8.6",
@@ -259,10 +842,102 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "optional": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
     },
     "dropzone": {
       "version": "5.7.0",
@@ -279,10 +954,28 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.395",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.395.tgz",
+      "integrity": "sha512-kdn2cX6hZXDdz/O2Q8tZscITlsSv1a/7bOq/fQs7QAJ9iaRlnhZPccarNhxZv1tXgmgwCnKp/1lJNYLOG8Dxiw==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -293,22 +986,118 @@
         "prr": "~1.0.1"
       }
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^2.1.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "optional": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "optional": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "optional": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fastq": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
+      "integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -327,10 +1116,28 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "fullcalendar": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.10.1.tgz",
       "integrity": "sha512-E0ioaHVmwdS4es8pNTUNva7505wPkUMFdn9JGFLYo+J12ARhN3zDBwoPj2DfB8rL7Yc1sSve+FqDHC3s2SZ7Fw=="
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -339,6 +1146,92 @@
       "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "globby": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+      "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+      "dev": true
+    },
+    "gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -389,6 +1282,44 @@
         }
       }
     },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -410,11 +1341,81 @@
       "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
       "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
     },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "dev": true
+    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "optional": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "interactjs": {
       "version": "1.8.4",
@@ -425,11 +1426,113 @@
         "@interactjs/types": "1.8.4"
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "optional": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-whitespace-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+      "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -481,16 +1584,41 @@
       "resolved": "https://registry.npmjs.org/jquery.fancytree/-/jquery.fancytree-2.34.0.tgz",
       "integrity": "sha512-GFHdiEG6D5V+sE1hq6WCLOK48d2FFutVqG3qzV73pOrCNQpHCTWDpw4anm9wWk7128nbrR/BXVk4PtxuQxEszA=="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "optional": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -524,6 +1652,18 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "known-css-properties": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.18.0.tgz",
+      "integrity": "sha512-69AgJ1rQa7VvUsd2kpvVq+VeObDuo3zrj0CzM5Slmf6yduQFAI2kXPDQJR2IE/u6MSAUOJrwSzjg5vlz8qcMiw==",
+      "dev": true
     },
     "less": {
       "version": "3.11.1",
@@ -571,6 +1711,18 @@
         }
       }
     },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "loader-utils": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
@@ -596,15 +1748,108 @@
         }
       }
     },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true
+    },
     "magnific-popup": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/magnific-popup/-/magnific-popup-1.1.0.tgz",
       "integrity": "sha1-PnNixb0Y9nhf6Z5Z0BPiCvM9MEk="
+    },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
+    "markdown-escapes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+      "dev": true
+    },
+    "markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+      "dev": true
+    },
+    "mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true
+    },
+    "mdast-util-compact": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
+      "integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "meow": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.0.tgz",
+      "integrity": "sha512-iIAoeI01v6pmSfObAAWFoITAA4GgiT45m4SmJgoxtZfvI0fyZwhV4d0lTwiUXvAKIPlma05Feb2Xngl52Mj5Cg==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.1.1",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.0.0",
+        "minimist-options": "^4.0.1",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.0",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.8.1",
+        "yargs-parser": "^18.1.1"
+      }
+    },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
     },
     "microplugin": {
       "version": "0.0.3",
@@ -620,14 +1865,31 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "optional": true,
       "requires": {
         "mime-db": "1.43.0"
+      }
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -635,11 +1897,20 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minimist-options": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
+      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "optional": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -657,16 +1928,67 @@
         "moment": ">= 2.9.0"
       }
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+      "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-selector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+      "dev": true
+    },
     "nprogress": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha1-y480xTIT2JVyP8urkH6UIq28r7E="
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "optimist": {
       "version": "0.6.1",
@@ -677,11 +1999,109 @@
         "wordwrap": "~0.0.2"
       }
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "optional": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
     },
     "pnotify": {
       "version": "4.0.0",
@@ -692,6 +2112,150 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
+    "postcss": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      }
+    },
+    "postcss-html": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+      "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.10.0"
+      }
+    },
+    "postcss-jsx": {
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.4.tgz",
+      "integrity": "sha512-jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": ">=7.2.2"
+      }
+    },
+    "postcss-less": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+      "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
+    "postcss-markdown": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+      "integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
+      "dev": true,
+      "requires": {
+        "remark": "^10.0.1",
+        "unist-util-find-all-after": "^1.0.2"
+      }
+    },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+      "dev": true
+    },
+    "postcss-reporter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+      "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "lodash": "^4.17.11",
+        "log-symbols": "^2.2.0",
+        "postcss": "^7.0.7"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        }
+      }
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "dev": true
+    },
+    "postcss-safe-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+      "integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.26"
+      }
+    },
+    "postcss-sass": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.2.tgz",
+      "integrity": "sha512-hcRgnd91OQ6Ot9R90PE/khUDCJHG8Uxxd3F7Y0+9VHjBiJgNv7sK5FxyHMCBtoLmmkzVbSj3M3OlqUfLJpq0CQ==",
+      "dev": true,
+      "requires": {
+        "gonzales-pe": "^4.2.4",
+        "postcss": "^7.0.21"
+      }
+    },
+    "postcss-scss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
+      "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-sorting": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
+      "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14",
+        "postcss": "^7.0.17"
+      }
+    },
+    "postcss-syntax": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+      "dev": true
+    },
+    "postcss-value-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+      "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+      "dev": true
     },
     "promise": {
       "version": "7.3.1",
@@ -725,6 +2289,115 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "optional": true
     },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "redeyed": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
@@ -739,6 +2412,80 @@
           "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
         }
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
+    },
+    "remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+      "integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
+      "dev": true,
+      "requires": {
+        "remark-parse": "^6.0.0",
+        "remark-stringify": "^6.0.0",
+        "unified": "^7.0.0"
+      }
+    },
+    "remark-parse": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^1.1.0",
+        "mdast-util-compact": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^1.0.1",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -768,6 +2515,42 @@
         "uuid": "^3.3.2"
       }
     },
+    "resolve": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -776,7 +2559,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "optional": true
     },
     "selectize": {
       "version": "0.12.6",
@@ -786,6 +2570,12 @@
         "microplugin": "0.0.3",
         "sifter": "^0.5.1"
       }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "sifter": {
       "version": "0.5.4",
@@ -799,11 +2589,79 @@
         "optimist": "^0.6.1"
       }
     },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true
     },
     "spectrum-colorpicker": {
       "version": "1.8.0",
@@ -827,6 +2685,309 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "state-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
+      }
+    },
+    "stringify-entities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+      "dev": true
+    },
+    "stylelint": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.3.0.tgz",
+      "integrity": "sha512-ehNzQu9JAbxuiNhUhmoyPgMjIdz7Fg1AxC5urPVhKotto/faF5GxwljSoLvQa6pB6yd+BVuofApWjWT/6/rBMQ==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^9.7.5",
+        "balanced-match": "^1.0.0",
+        "chalk": "^3.0.0",
+        "cosmiconfig": "^6.0.0",
+        "debug": "^4.1.1",
+        "execall": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^7.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.0.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.1.0",
+        "ignore": "^5.1.4",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "known-css-properties": "^0.18.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "log-symbols": "^3.0.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^6.1.0",
+        "micromatch": "^4.0.2",
+        "normalize-selector": "^0.2.0",
+        "postcss": "^7.0.27",
+        "postcss-html": "^0.36.0",
+        "postcss-jsx": "^0.36.4",
+        "postcss-less": "^3.1.4",
+        "postcss-markdown": "^0.36.0",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-reporter": "^6.0.1",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^4.0.2",
+        "postcss-sass": "^0.4.2",
+        "postcss-scss": "^2.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-syntax": "^0.36.2",
+        "postcss-value-parser": "^4.0.3",
+        "resolve-from": "^5.0.0",
+        "slash": "^3.0.0",
+        "specificity": "^0.4.1",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "style-search": "^0.1.0",
+        "sugarss": "^2.0.0",
+        "svg-tags": "^1.0.0",
+        "table": "^5.4.6",
+        "v8-compile-cache": "^2.1.0",
+        "write-file-atomic": "^3.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "stylelint-config-sass-guidelines": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-7.0.0.tgz",
+      "integrity": "sha512-nWO8gtxv8T+UbAw7iM0RQp6VC3iJgOvqEIeqFBgHW+KgpZu65lYoe9Bf0fqvqxKJ/ngBD+/65BT3ql2u+7Qasg==",
+      "dev": true,
+      "requires": {
+        "stylelint-order": "^4.0.0",
+        "stylelint-scss": "^3.4.0"
+      }
+    },
+    "stylelint-order": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.0.0.tgz",
+      "integrity": "sha512-bXV0v+jfB0+JKsqIn3mLglg1Dj2QCYkFHNfL1c+rVMEmruZmW5LUqT/ARBERfBm8SFtCuXpEdatidw/3IkcoiA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss": "^7.0.26",
+        "postcss-sorting": "^5.0.1"
+      }
+    },
+    "stylelint-scss": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.16.0.tgz",
+      "integrity": "sha512-dAWs/gagdPYO3VDdvgRv5drRBMcWI4E//z3AXPAY1qYkSdXCEVJtEW+R9JtinG0U2rcJIu5XWaVddPQeaaufzw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "sugarss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+      "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "dev": true
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -837,6 +2998,24 @@
         "punycode": "^2.1.1"
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
+      "dev": true
+    },
     "tristate": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tristate/-/tristate-1.2.0.tgz",
@@ -844,6 +3023,12 @@
       "requires": {
         "jquery": ">=1.6.2"
       }
+    },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
     },
     "tslib": {
       "version": "1.11.0",
@@ -862,27 +3047,147 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "underscore": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
       "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
+    "unherit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "unified": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "@types/vfile": "^3.0.0",
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^3.0.0",
+        "x-is-string": "^0.1.0"
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "unist-util-find-all-after": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz",
+      "integrity": "sha512-lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "dev": true
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "optional": true,
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "optional": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "verror": {
       "version": "1.10.0",
@@ -895,15 +3200,127 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
+      },
+      "dependencies": {
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+          "dev": true
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "dev": true,
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
     "vue": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "wordwrap": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
+      "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.7"
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "watch-poll": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js --watch-poll",
     "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
     "prod": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "lint:css": "stylelint **/*.scss",
+    "lint:fix:css": "stylelint **/*.scss --fix"
+
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.11.2",
@@ -55,5 +58,9 @@
   "bugs": {
     "url": "https://github.com/concrete5/concrete5/issues"
   },
-  "homepage": "https://github.com/concrete5/concrete5#readme"
+  "homepage": "https://github.com/concrete5/concrete5#readme",
+  "devDependencies": {
+    "stylelint": "^13.3.0",
+    "stylelint-config-sass-guidelines": "^7.0.0"
+  }
 }


### PR DESCRIPTION
A whole lot of changes in these files due to stylelint's ordering requirement. Merging will be painful for a bit after this merges, but better to pull the bandaid now than later.

There are a lot of cases of `-webkit-` or `-moz-` vendor prefixes, we don't need these since we pass our stuff through autoprefixer. I removed those where it made sense and just disabled the rule for files where it was too much of a hassle to immediately fix.