### PR TITLE
Add semicolons to old IIFEs to allow prod building to work

### DIFF
--- a/assets/calendar/js/backend/duration.js
+++ b/assets/calendar/js/backend/duration.js
@@ -435,4 +435,4 @@
     }
 
     global.ConcreteDurationSelector = ConcreteDurationSelector
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/asset-loader.js
+++ b/assets/cms/js/asset-loader.js
@@ -50,4 +50,4 @@
     }
 
     global.ConcreteAssetLoader = ConcreteAssetLoader
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/area.js
+++ b/assets/cms/js/edit-mode/area.js
@@ -414,4 +414,4 @@
             })
         }
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/block.js
+++ b/assets/cms/js/edit-mode/block.js
@@ -641,4 +641,4 @@
             })
         }
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/blocktype.js
+++ b/assets/cms/js/edit-mode/blocktype.js
@@ -204,4 +204,4 @@ import * as _ from 'underscore'
             }
         }
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/container.js
+++ b/assets/cms/js/edit-mode/container.js
@@ -58,4 +58,4 @@ import * as _ from 'underscore';
         }
 
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/containerblock.js
+++ b/assets/cms/js/edit-mode/containerblock.js
@@ -38,4 +38,4 @@ import * as _ from 'underscore'
         }
 
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/dragarea.js
+++ b/assets/cms/js/edit-mode/dragarea.js
@@ -139,4 +139,4 @@
         }
 
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/duplicateblock.js
+++ b/assets/cms/js/edit-mode/duplicateblock.js
@@ -80,4 +80,4 @@ import * as _ from 'underscore'
             })
         }
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/editmode.js
+++ b/assets/cms/js/edit-mode/editmode.js
@@ -688,4 +688,4 @@
             })
         }
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/layout.js
+++ b/assets/cms/js/edit-mode/layout.js
@@ -42,4 +42,4 @@ import * as _ from 'underscore'
         }
 
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/stack.js
+++ b/assets/cms/js/edit-mode/stack.js
@@ -58,4 +58,4 @@ import * as _ from 'underscore';
         }
 
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/stackblock.js
+++ b/assets/cms/js/edit-mode/stackblock.js
@@ -60,4 +60,4 @@ import * as _ from 'underscore'
         }
 
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/edit-mode/stackdisplay.js
+++ b/assets/cms/js/edit-mode/stackdisplay.js
@@ -24,4 +24,4 @@ import * as _ from 'underscore'
         }
 
     })
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/events.js
+++ b/assets/cms/js/events.js
@@ -142,4 +142,4 @@
         ns.event = ConcreteEvent
         return ConcreteEvent
     }(global.Concrete))
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/help/dialog.js
+++ b/assets/cms/js/help/dialog.js
@@ -31,4 +31,4 @@
     }
 
     global.ConcreteHelpDialog = ConcreteHelpDialog
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/help/guide-manager.js
+++ b/assets/cms/js/help/guide-manager.js
@@ -82,4 +82,4 @@
     }
 
     global.ConcreteHelpGuideManager = ConcreteHelpGuideManager
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/help/launcher.js
+++ b/assets/cms/js/help/launcher.js
@@ -59,4 +59,4 @@
     }
 
     global.ConcreteHelpLauncher = ConcreteHelpLauncher
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/legacy-dialog.js
+++ b/assets/cms/js/legacy-dialog.js
@@ -378,4 +378,4 @@
     }
 
     $.ui.dialog.prototype._focusTabbable = $.noop
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/search/field-selector.js
+++ b/assets/cms/js/search/field-selector.js
@@ -88,4 +88,4 @@
     }
 
     global.ConcreteSearchFieldSelector = ConcreteSearchFieldSelector
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/cms/js/toolbar.js
+++ b/assets/cms/js/toolbar.js
@@ -351,4 +351,4 @@
             }
         }
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/conversations/js/frontend/attachments.js
+++ b/assets/conversations/js/frontend/attachments.js
@@ -312,4 +312,4 @@ import Dropzone from 'dropzone/dist/dropzone'
     $.fn.concreteConversationAttachments.localize = function(dictionary) {
         $.extend(true, i18n, dictionary)
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi

--- a/assets/conversations/js/frontend/conversations.js
+++ b/assets/conversations/js/frontend/conversations.js
@@ -888,4 +888,4 @@ window._ = _
             }
         }
     }
-})(window, jQuery)
+})(window, jQuery); // eslint-disable-line semi


### PR DESCRIPTION
Building for prod in concrete5's repo would result in javascript errors. After digging it was clear that the cause was removing semicolons from the end of IIFEs so I've gone through and added them back.

This can also likely be resolved in a compliant way by adding leading semicolons, but we should just refactor as possible to get away from IIFEs entirely.