### PR TITLE
Fix linting JS files on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.9.3",
   "description": "The asset framework and dependencies for Concrete CMS.",
   "scripts": {
-    "lint": "standardx '**/*.{js,vue}' && stylelint assets/**/*.scss",
-    "lint:fix": "standardx '**/*.{js,vue}' --fix && stylelint assets/**/*.scss --fix",
+    "lint": "standardx \"**/*.{js,vue}\" && stylelint assets/**/*.scss",
+    "lint:fix": "standardx \"**/*.{js,vue}\" --fix && stylelint assets/**/*.scss --fix",
     "lint:css": "stylelint assets/**/*.scss",
     "lint:fix:css": "stylelint assets/**/*.scss --fix",
-    "lint:js": "standardx '**/*.{js,vue}'",
-    "lint:fix:js": "standardx '**/*.{js,vue}' --fix",
+    "lint:js": "standardx \"**/*.{js,vue}\"",
+    "lint:fix:js": "standardx \"**/*.{js,vue}\" --fix",
     "storybook": "start-storybook -p55600"
   },
   "dependencies": {


### PR DESCRIPTION
Windows doesn't accept single quotes to enclose parameter values, only double quotes.