### PR TITLE
Fix fontawesome by using their official CDN to serve webfonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,3 +4,6 @@
         padding: 1em;
     }
 </style>
+
+<!-- Include fontawesome from CDN because I couldn't get the webfont working from node_modules -->
+<script src="https://kit.fontawesome.com/de35fa886c.js" crossorigin="anonymous"></script>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,2 @@
 import '@fortawesome/fontawesome-free/css/all.css'
-import '@fortawesome/fontawesome-free/js/all.js'
-
 import './assets/scss/theme/main.scss'


### PR DESCRIPTION
I've gone back and forth with how we should include fontawesome in storybook and I've struggled to get the webfont working out of NPM. I think what we need is to set the `$fa-font-path` to something that webpack is set to render, but I haven't found the right combination of things to get that working.

Instead let's just include their official cdn version.