### PR TITLE
Fix a regression in iconbutton

### DIFF
--- a/assets/cms/components/IconButton.vue
+++ b/assets/cms/components/IconButton.vue
@@ -1,6 +1,6 @@
 <template functional>
     <button
-        v-bind="{type: props.type, style: props.style}"
+        v-bind="{type: props.buttonType, style: props.style}"
         @click='listeners.click'
         class='btn'
         :class="[$options.classMap[props.type] || $options.defaultClass, props.buttonClass]"
@@ -39,7 +39,7 @@ export default {
     props: {
         type: {
             type: String,
-            default: 'button'
+            default: types.add
         },
         disabled: {
             type: Boolean,
@@ -59,9 +59,9 @@ export default {
         iconColor: {
             type: String
         },
-        format: {
+        buttonType: {
             type: String,
-            default: 'floating'
+            default: 'button'
         },
         buttonClass: [String, Array, Object]
     },


### PR DESCRIPTION
Fix a mixup in prop names in the icon button component. We were using the `type` prop for two different things, instead I've added a new prop 'buttonType' that handles setting the `type='..'` value on the button.