### PR TITLE
Fix tooltip positioning

### DIFF
--- a/assets/cms/scss/_tooltips.scss
+++ b/assets/cms/scss/_tooltips.scss
@@ -19,8 +19,10 @@
  * Tooltips
  */
 div#ccm-tooltip-holder {
-  position: relative;
-  z-index: $index-level-tooltip-holder;
+  &,
+  .tooltip {
+    z-index: $index-level-tooltip-holder;
+  }
 }
 
 div.tooltip-inner {


### PR DESCRIPTION
The position of tooltips is correct when relative to elements in dialogs, but it's wrong in other cases:

![immagine](https://user-images.githubusercontent.com/928116/82750900-da931300-9db3-11ea-8f77-476cc94a013d.png)

Removing `position: relative;` from the `ccm-tooltip-holder` element seems to fix this issue (but we have to set the z-index of contained tooltips):

![immagine](https://user-images.githubusercontent.com/928116/82750904-e252b780-9db3-11ea-94fd-2f869458943b.png)
