### PR TITLE
Gallery block removing confirmation dialog  and fixing buttons

### DIFF
--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -138,7 +138,6 @@ export default {
             this.activeImage = null
         },
         deleteImage(image) {
-            
             if (this.activeImage === image) {
                 this.closeImage()
             }

--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -138,14 +138,13 @@ export default {
             this.activeImage = null
         },
         deleteImage(image) {
-            if (confirm('Really delete this image?')) {
-                if (this.activeImage === image) {
-                    this.closeImage()
-                }
-
-                const index = this.gallery.indexOf(image)
-                this.gallery.splice(index, 1)
+            
+            if (this.activeImage === image) {
+                this.closeImage()
             }
+
+            const index = this.gallery.indexOf(image)
+            this.gallery.splice(index, 1)
         },
         addImage() {
             console.log('Add Image')

--- a/assets/cms/components/gallery/ImageCell.vue
+++ b/assets/cms/components/gallery/ImageCell.vue
@@ -1,6 +1,6 @@
 <template functional>
     <div class="ccm-image-cell text-center" :class="{ active: props.isActive }">
-        <button class="delete" @click="listeners.delete">
+        <button type="button" class="delete" @click="listeners.delete">
             <Icon icon="times" type="fas" color="#fff"/>
         </button>
         <img :src="props.src"

--- a/assets/cms/components/gallery/ImageDetail.vue
+++ b/assets/cms/components/gallery/ImageDetail.vue
@@ -2,7 +2,7 @@
     <div class="ccm-gallery-image-details">
         <div class="image-preview text-center">
             <img :src="this.$props.image.imageUrl" />
-            <button class="btn btn-secondary" @click="$emit('delete')">Remove from Gallery</button>
+            <button type="button" class="btn btn-secondary" @click="$emit('delete')">Remove from Gallery</button>
         </div>
         <div class="image-details">
             <section>


### PR DESCRIPTION
- Removing the confirmation dialog closes the block's window when editing in the page.
- Fixing and updating the buttons 