### PR TITLE
Gallery block component updates

### DIFF
--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -104,6 +104,7 @@
 
     .ccm-image-cell-container {
       position: relative;
+      min-width: 130px;
       width: 20%;
     }
   }
@@ -136,7 +137,7 @@ export default {
                 this.activeImage = index
                 this.$nextTick(() => {
                     const container = this.$refs.imageContainer
-                    container.scrollTop = $(this.$refs.cell[index]).closest('.ccm-image-cell-container').get(0).offsetTop
+                    container.scrollTop = this.$refs.cell[index].offsetTop
                 })
             }
         },
@@ -165,7 +166,8 @@ export default {
                         imageUrl: file.url,
                         thumbUrl: file.url,
                         displayChoices: JSON.parse(JSON.stringify(me.choices)),
-                        fileSize: file.fileSize || '-'
+                        fileSize: file.fileSize || '-',
+                        detailUrl: file.urlDetail
                     })
 
                     const lastIndex = me.gallery.length - 1

--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -156,7 +156,6 @@ export default {
             ConcreteFileManager.launchDialog(function(data) {
                 ConcreteFileManager.getFileDetails(data.fID, function(file) {
                     file = file.files[0] || {}
-                    console.log(file)
                     me.gallery.push({
                         id: data.fID,
                         title: file.title,

--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -91,11 +91,11 @@
   }
 
   .image-container {
+    align-items: center;
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
     overflow-y: auto;
-    align-items: center;
     position: relative;
 
     &.active-image {
@@ -103,8 +103,8 @@
     }
 
     .ccm-image-cell-container {
-      width: 20%;
       position: relative;
+      width: 20%;
     }
   }
 }
@@ -123,7 +123,7 @@ export default {
     },
     data: () => ({
         activeTab: 'image',
-        activeImage: null,
+        activeImage: null
     }),
     methods: {
         openTab(tab) {
@@ -165,7 +165,7 @@ export default {
                         imageUrl: file.url,
                         thumbUrl: file.url,
                         displayChoices: JSON.parse(JSON.stringify(me.choices)),
-                        fileSize: file.fileSize || '-',
+                        fileSize: file.fileSize || '-'
                     })
 
                     const lastIndex = me.gallery.length - 1

--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -103,8 +103,8 @@
     }
 
     .ccm-image-cell-container {
-      position: relative;
       min-width: 130px;
+      position: relative;
       width: 20%;
     }
   }

--- a/assets/cms/components/gallery/ImageCell.vue
+++ b/assets/cms/components/gallery/ImageCell.vue
@@ -19,16 +19,18 @@
   margin: 10px;
   position: relative;
 
+  &:hover {
+    .delete {
+      opacity: 1;
+      transition: opacity 0.2s ease-out;
+    }
+  }
+
   &:hover,
   &.active {
     img {
       border: 2px solid #4a90e2;
       opacity: 1;
-    }
-
-    .delete {
-      opacity: 1;
-      transition: opacity 0.2s ease-out;
     }
   }
 

--- a/assets/cms/components/gallery/ImageCell.vue
+++ b/assets/cms/components/gallery/ImageCell.vue
@@ -3,11 +3,10 @@
         <button type="button" class="delete" @click="listeners.delete">
             <Icon icon="times" type="fas" color="#fff"/>
         </button>
-        <img :src="props.src"
-            :style="{ width: props.size + 'px', height: props.size + 'px' }"
-            @click="listeners.click"
-        />
-        <p>{{ props.fileSize }}</p>
+        <div @click="listeners.click">
+            <img :src="props.src" :style="{ width: props.size + 'px', height: props.size + 'px' }" />
+            <p>{{ props.fileSize }}</p>
+        </div>
     </div>
 </template>
 

--- a/assets/cms/components/gallery/ImageDetail.vue
+++ b/assets/cms/components/gallery/ImageDetail.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="ccm-gallery-image-details">
         <div class="image-preview text-center">
-            <img :src="this.$props.image.imageUrl" />
+            <div class="image-container">
+                <img :src="this.$props.image.imageUrl" />
+            </div>
             <IconButton
               icon="trash-alt"
               icon-type="far"
@@ -18,6 +20,9 @@
 
                 <p class="image-title">{{this.$props.image.title}}</p>
                 <p class="image-description">{{this.$props.image.description}}</p>
+                <p class="image-attribute" v-for="([key, value], idx) of image.attributes" :key="idx">
+                    <strong>{{key}}:</strong> {{value}}
+                </p>
 
                 <div class="mb-4 text-right">
                     <IconButton
@@ -68,16 +73,24 @@
 
   .image-preview,
   .image-details {
+    width: 50%;
     flex: 1;
     padding: 10px;
   }
 
   .image-preview {
+    .image-container {
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
     img {
-      height: auto;
-      height: 270px;
       margin-bottom: 10px;
+      max-width: 100%;
+      max-height: 100%;
       width: auto;
+      height: auto;
     }
   }
 

--- a/assets/cms/components/gallery/ImageDetail.vue
+++ b/assets/cms/components/gallery/ImageDetail.vue
@@ -30,6 +30,7 @@
                       icon-type="fas"
                       @click="goToDetails($props.image.detailUrl)"
                       type="outline"
+                      v-if="$props.image.detailUrl"
                     >
                       Edit Attributes
                     </IconButton>

--- a/assets/cms/components/gallery/ImageDetail.vue
+++ b/assets/cms/components/gallery/ImageDetail.vue
@@ -73,24 +73,25 @@
 
   .image-preview,
   .image-details {
-    width: 50%;
     flex: 1;
     padding: 10px;
+    width: 50%;
   }
 
   .image-preview {
     .image-container {
-      height: 100%;
-      display: flex;
       align-items: center;
+      display: flex;
+      height: 100%;
       justify-content: center;
     }
+
     img {
-      margin-bottom: 10px;
-      max-width: 100%;
-      max-height: 100%;
-      width: auto;
       height: auto;
+      margin-bottom: 10px;
+      max-height: 100%;
+      max-width: 100%;
+      width: auto;
     }
   }
 

--- a/stories/gallery/galleryEdit.stories.js
+++ b/stories/gallery/galleryEdit.stories.js
@@ -92,60 +92,6 @@ const galleryData = [
         }
     },
     {
-        id: 4,
-        title: 'Mayan Temple',
-        description: 'A picture of mayan temple in Yucatan, Mexico.',
-        extension: 'jpg',
-        attributes: {},
-        fileSize: '310 kb',
-        imageUrl: 'https://images.pexels.com/photos/3290068/pexels-photo-3290068.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260',
-        thumbUrl: 'https://images.pexels.com/photos/3290068/pexels-photo-3290068.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260',
-        detailUrl: 'https://www.google.com/',
-        displayChoices: {
-            'gallery-specific-options': {
-                value: '',
-                title: 'Gallery Specific Options',
-                type: 'text'
-            },
-            size: {
-                value: '0',
-                title: 'Size',
-                type: 'select',
-                options: {
-                    square: 'Square Image',
-                    default: 'Keep Image Aspect Ratio'
-                }
-            }
-        }
-    },
-    {
-        id: 5,
-        title: 'The Base',
-        description: 'A picture of an interesting stylish looking base.',
-        extension: 'jpg',
-        attributes: {},
-        fileSize: '199 kb',
-        imageUrl: 'https://images.pexels.com/photos/4207892/pexels-photo-4207892.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=500',
-        thumbUrl: 'https://images.pexels.com/photos/4207892/pexels-photo-4207892.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=500',
-        detailUrl: 'https://www.google.com/',
-        displayChoices: {
-            'gallery-specific-options': {
-                value: '',
-                title: 'Gallery Specific Options',
-                type: 'text'
-            },
-            size: {
-                value: '0',
-                title: 'Size',
-                type: 'select',
-                options: {
-                    square: 'Square Image',
-                    default: 'Keep Image Aspect Ratio'
-                }
-            }
-        }
-    },
-    {
         id: 6,
         title: 'Landscape Montecarlo',
         description: 'A picture Montecarlo desert in Italy',


### PR DESCRIPTION
- Use icon-button for image adding
- Use file manager popup to add files
- Wrap the images in a container that makes sizing and positioning properly a little bit easier
- Add a `ref` to the cells so that we can scroll to them without needing an event triggered by the user. This is helpful for setting a newly edited image as active
- Switch `activeImage` tracker to track the active index rather than the image object
- Pass through choices so that we can initialize newly added images properly
- Don't show delete button if image isn't hovered
- Center and position the detail preview image in the left half of the dialog