### PR TITLE
Moving styling out the component so can be re-usable glabally

### DIFF
--- a/assets/cms/components/gallery/ImageCell.vue
+++ b/assets/cms/components/gallery/ImageCell.vue
@@ -39,10 +39,10 @@
     }
 
     .delete {
-      background-color: $gray-600;
+      background-color: #6a6f7b;
       border: 0;
       border-radius: 20px;
-      box-shadow: $image-cell-box-shadow;
+      box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.2);
       float: left;
       height: 30px;
       margin-right: -10px;

--- a/assets/cms/components/gallery/ImageCell.vue
+++ b/assets/cms/components/gallery/ImageCell.vue
@@ -1,6 +1,6 @@
 <template functional>
     <div class="ccm-image-cell-grid">
-      <div class="ccm-image-cell v-component text-center" :class="{ active: props.isActive }">
+      <div class="ccm-image-cell text-center" :class="{ active: props.isActive }">
           <button type="button" class="delete" @click="listeners.delete">
               <Icon icon="times" type="fas" color="#fff"/>
           </button>
@@ -11,6 +11,50 @@
       </div>
     </div>
 </template>
+
+<style lang="scss" scoped>
+  .ccm-image-cell {
+    cursor: pointer;
+    display: inline-flex;
+    flex-direction: column;
+    margin: 0.625rem;
+    position: relative;
+
+    &:hover {
+      .delete {
+        opacity: 1;
+        transition: opacity 0.2s ease-out;
+      }
+    }
+
+    p {
+      font-size: 1rem;
+      letter-spacing: 0;
+      margin-top: 0.625rem;
+      text-transform: uppercase;
+    }
+
+    img {
+      padding: 0.5rem;
+    }
+
+    .delete {
+      background-color: $gray-600;
+      border: 0;
+      border-radius: 20px;
+      box-shadow: $image-cell-box-shadow;
+      float: left;
+      height: 30px;
+      margin-right: -10px;
+      margin-top: -10px;
+      opacity: 0;
+      position: absolute;
+      right: 0;
+      width: 30px;
+      z-index: 90;
+    }
+  }
+</style>
 
 <script>
 import Icon from '../Icon'

--- a/assets/cms/components/gallery/ImageCell.vue
+++ b/assets/cms/components/gallery/ImageCell.vue
@@ -1,69 +1,16 @@
 <template functional>
-    <div class="ccm-image-cell text-center" :class="{ active: props.isActive }">
-        <button type="button" class="delete" @click="listeners.delete">
-            <Icon icon="times" type="fas" color="#fff"/>
-        </button>
-        <div @click="listeners.click">
-            <img :src="props.src" :style="{ width: props.size + 'px', height: props.size + 'px' }" />
-            <p>{{ props.fileSize }}</p>
-        </div>
+    <div class="ccm-image-cell-grid">
+      <div class="ccm-image-cell v-component text-center" :class="{ active: props.isActive }">
+          <button type="button" class="delete" @click="listeners.delete">
+              <Icon icon="times" type="fas" color="#fff"/>
+          </button>
+          <div @click="listeners.click">
+              <img :src="props.src" :style="{ width: props.size + 'px', height: props.size + 'px' }" />
+              <p>{{ props.fileSize }}</p>
+          </div>
+      </div>
     </div>
 </template>
-
-<style lang="scss" scoped>
-.ccm-image-cell {
-  cursor: pointer;
-  display: inline-flex;
-  flex-direction: column;
-  margin: 10px;
-  position: relative;
-
-  &:hover {
-    .delete {
-      opacity: 1;
-      transition: opacity 0.2s ease-out;
-    }
-  }
-
-  &:hover,
-  &.active {
-    img {
-      border: 2px solid #4a90e2;
-      opacity: 1;
-    }
-  }
-
-  p {
-    color: #676b74;
-    font-size: 1rem;
-    letter-spacing: 0;
-    margin-top: 0.625rem;
-    text-transform: uppercase;
-  }
-
-  img {
-    border: 2px solid #979797;
-    box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.2);
-    opacity: 0.7;
-    padding: 0.5rem;
-    transition: opacity 0.5s ease-out;
-  }
-
-  .delete {
-    background-color: #6a6f7b;
-    border-radius: 20px;
-    float: left;
-    height: 30px;
-    margin-right: -10px;
-    margin-top: -10px;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    width: 30px;
-    z-index: 90;
-  }
-}
-</style>
 
 <script>
 import Icon from '../Icon'

--- a/assets/cms/scss/file-manager/_image-cell.scss
+++ b/assets/cms/scss/file-manager/_image-cell.scss
@@ -30,48 +30,6 @@
         transition: $transition-base;
         width: 120px;
       }
-
-      &.v-component {
-        cursor: pointer;
-        display: inline-flex;
-        flex-direction: column;
-        margin: 10px;
-        position: relative;
-
-        &:hover {
-          .delete {
-            opacity: 1;
-            transition: opacity 0.2s ease-out;
-          }
-        }
-
-        p {
-          font-size: 1rem;
-          letter-spacing: 0;
-          margin-top: 0.625rem;
-          text-transform: uppercase;
-        }
-
-        img {
-          padding: 0.5rem;
-        }
-
-        .delete {
-          background-color: $gray-600;
-          border: 0;
-          border-radius: 20px;
-          box-shadow: $image-cell-box-shadow;
-          float: left;
-          height: 30px;
-          margin-right: -10px;
-          margin-top: -10px;
-          opacity: 0;
-          position: absolute;
-          right: 0;
-          width: 30px;
-          z-index: 90;
-        }
-      }
     }
 
   }

--- a/assets/cms/scss/file-manager/_image-cell.scss
+++ b/assets/cms/scss/file-manager/_image-cell.scss
@@ -30,6 +30,48 @@
         transition: $transition-base;
         width: 120px;
       }
+
+      &.v-component {
+        cursor: pointer;
+        display: inline-flex;
+        flex-direction: column;
+        margin: 10px;
+        position: relative;
+
+        &:hover {
+          .delete {
+            opacity: 1;
+            transition: opacity 0.2s ease-out;
+          }
+        }
+
+        p {
+          font-size: 1rem;
+          letter-spacing: 0;
+          margin-top: 0.625rem;
+          text-transform: uppercase;
+        }
+
+        img {
+          padding: 0.5rem;
+        }
+
+        .delete {
+          background-color: $gray-600;
+          border: 0;
+          border-radius: 20px;
+          box-shadow: $image-cell-box-shadow;
+          float: left;
+          height: 30px;
+          margin-right: -10px;
+          margin-top: -10px;
+          opacity: 0;
+          position: absolute;
+          right: 0;
+          width: 30px;
+          z-index: 90;
+        }
+      }
     }
 
   }


### PR DESCRIPTION
This PR moves out the image cell's styling to `_image-cell.scss` With this change we are centralizing the styling so can be used globally. 
