### PR TITLE
Adds File Sets Tab - inPage File Chooser Component

### DIFF
--- a/assets/cms/components/file-manager/Chooser.vue
+++ b/assets/cms/components/file-manager/Chooser.vue
@@ -21,9 +21,10 @@
                     <div key="recent" v-if="activeNavItem === 'recent'">
                         <chooser-header v-bind:resultsFormFactor.sync="resultsFormFactor"
                                         title="Recently Uploaded"></chooser-header>
-                        <recent-files v-bind:selectedFiles.sync="selectedFiles"
-                                      v-bind:resultsFormFactor.sync="resultsFormFactor"
-                                      v-if="activeNavItem === 'recent'" />
+                        <files :selectedFiles.sync="selectedFiles"
+                            :resultsFormFactor.sync="resultsFormFactor"
+                            routePath="/ccm/system/file/chooser/recent"
+                            v-if="activeNavItem === 'recent'" />
                     </div>
 
                     <div key="filemanager" v-if="activeNavItem === 'filemanager'">
@@ -34,7 +35,9 @@
                     <div key="sets" v-if="activeNavItem === 'sets'">
                         <chooser-header v-bind:resultsFormFactor.sync="resultsFormFactor"
                                         title="File Sets"></chooser-header>
-                        Coming Soon
+                        <sets :selectedFiles.sync="selectedFiles"
+                            :resultsFormFactor.sync="resultsFormFactor"
+                            v-if="activeNavItem === 'sets'"/>
                     </div>
                     <div key="presets" v-if="activeNavItem === 'presets'">
                         <chooser-header v-bind:resultsFormFactor.sync="resultsFormFactor"
@@ -66,11 +69,14 @@
 
 <script>
 import ChooserHeader from './Chooser/Header'
-import RecentFiles from './Chooser/RecentFiles'
+import Files from './Chooser/Files'
+import Sets from './Chooser/Sets'
+
 export default {
     components: {
         ChooserHeader,
-        RecentFiles
+        Files,
+        Sets
     },
     props: {
     },

--- a/assets/cms/components/file-manager/Chooser/Sets.vue
+++ b/assets/cms/components/file-manager/Chooser/Sets.vue
@@ -1,0 +1,69 @@
+<template>
+    <div>
+        <div class="form-inline mt-3">
+            <div class="form-group ml-auto">
+                <label class="mr-2">File Set</label>
+                <select class="form-control file-set-menu" v-model="activeSet">
+                    <option value="" selected>Select a Set</option>
+                    <option v-for="set in sets" :key="set.id" :value="set.id">
+                        {{set.name}}
+                    </option>
+                </select>
+            </div>
+        </div>
+        <div class="mt-3" v-show="this.activeSet">
+            <files v-if="this.activeSet"
+                :selectedFiles.sync="selectedFiles"
+                :resultsFormFactor="this.$props.resultsFormFactor"
+                :routePath="this.routePath + this.activeSet"/>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.file-set-menu {
+  width: 300px !important;
+}
+</style>
+
+<script>
+/* eslint-disable no-new */
+import Files from './Files'
+
+export default {
+    components: {
+        Files
+    },
+    data: () => ({
+        sets: [],
+        activeSet: '',
+        selectedFiles: [],
+        routePath: '/ccm/system/file/chooser/get_file_set/'
+    }),
+    props: {
+        resultsFormFactor: {
+            type: String,
+            required: false,
+            default: 'grid' // grid | list
+        }
+    },
+    methods: {
+        getSets() {
+            new ConcreteAjaxRequest({
+                url: CCM_DISPATCHER_FILENAME + '/ccm/system/file/chooser/get_file_sets',
+                success: (e) => {
+                    this.sets = e
+                }
+            })
+        }
+    },
+    watch: {
+        selectedFiles: function(value) {
+            this.$emit('update:selectedFiles', value)
+        }
+    },
+    mounted() {
+        this.getSets()
+    }
+}
+</script>


### PR DESCRIPTION
As requested by #8754 this PR adds the File Sets Tab Component for the In Page File Chooser. 
We also modified the Recent Files Component and renamed it so can be usable across other components like in this case the File Sets component.

<img width="1286" alt="Screen Shot 2020-06-24 at 11 43 08 AM" src="https://user-images.githubusercontent.com/37560903/85614683-fc302600-b60f-11ea-91b3-743f59a9f115.png">
<img width="821" alt="Screen Shot 2020-06-24 at 11 43 30 AM" src="https://user-images.githubusercontent.com/37560903/85614694-005c4380-b610-11ea-8fcd-c539f227183a.png">
<img width="819" alt="Screen Shot 2020-06-24 at 11 43 41 AM" src="https://user-images.githubusercontent.com/37560903/85614701-03efca80-b610-11ea-8f94-dcf044e2a6ae.png">

Note: This new File Sets component also needs an update in the core for the Routes that feed this component.