### PR TITLE
Adding Search Component to In-Page File Chooser

### DIFF
--- a/assets/cms/components/file-manager/Chooser.vue
+++ b/assets/cms/components/file-manager/Chooser.vue
@@ -47,7 +47,9 @@
                     <div key="search" v-if="activeNavItem === 'search'">
                         <chooser-header v-bind:resultsFormFactor.sync="resultsFormFactor"
                                         title="Search"></chooser-header>
-                        Coming Soon
+                        <search :selectedFiles.sync="selectedFiles"
+                            :resultsFormFactor.sync="resultsFormFactor"
+                            v-if="activeNavItem === 'search'"/>
                     </div>
                     <div key="upload" v-if="activeNavItem === 'upload'">
                         <chooser-header title="File Manager" :showListSelector="false"></chooser-header>
@@ -71,12 +73,14 @@
 import ChooserHeader from './Chooser/Header'
 import Files from './Chooser/Files'
 import Sets from './Chooser/Sets'
+import Search from './Chooser/Search'
 
 export default {
     components: {
         ChooserHeader,
         Files,
-        Sets
+        Sets,
+        Search
     },
     props: {
     },

--- a/assets/cms/components/file-manager/Chooser/Search.vue
+++ b/assets/cms/components/file-manager/Chooser/Search.vue
@@ -46,15 +46,16 @@ export default {
         selectedFiles: function(value) {
             this.$emit('update:selectedFiles', value)
         }
-    },
+    }
 }
 </script>
 
 <style lang="scss" scoped>
 .search-icon {
-    display: inline-block;
-    .icon {
-        font-size:7rem;
-    }
+  display: inline-block;
+
+  .icon {
+    font-size: 7rem;
+  }
 }
 </style>

--- a/assets/cms/components/file-manager/Chooser/Search.vue
+++ b/assets/cms/components/file-manager/Chooser/Search.vue
@@ -1,0 +1,60 @@
+<template>
+    <div>
+        <div class="form-inline mt-3">
+            <div class="form-group ml-auto">
+                <label class="mr-2">Search</label>
+                <input class="form-control" v-model="keyword" />
+            </div>
+        </div>
+        <div v-show="!keyword" class="text-center mt-5">
+            <span class="search-icon my-4">
+                <Icon icon="search" type="fas" color="#f4f4f4"/>
+            </span>
+            <p><b>Let's get some info on what you're looking for.</b></p>
+        </div>
+        <div>
+            <files v-if="this.keyword"
+                :selectedFiles.sync="selectedFiles"
+                :resultsFormFactor="this.$props.resultsFormFactor"
+                :routePath="this.routePath + this.keyword"/>
+        </div>
+    </div>
+</template>
+
+<script>
+import Icon from '../../Icon'
+import Files from '../Chooser/Files'
+
+export default {
+    components: {
+        Icon,
+        Files
+    },
+    data: () => ({
+        keyword: '',
+        selectedFiles: [],
+        routePath: '/ccm/system/file/chooser/search/'
+    }),
+    props: {
+        resultsFormFactor: {
+            type: String,
+            required: false,
+            default: 'grid' // grid | list
+        }
+    },
+    watch: {
+        selectedFiles: function(value) {
+            this.$emit('update:selectedFiles', value)
+        }
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.search-icon {
+    display: inline-block;
+    .icon {
+        font-size:7rem;
+    }
+}
+</style>


### PR DESCRIPTION
As requested by #8754 we are adding the Search Component for our In-Page File Chooser. 

<img width="1309" alt="Screen Shot 2020-06-26 at 10 30 07 AM" src="https://user-images.githubusercontent.com/37560903/85884818-139a1b00-b798-11ea-939c-3b7fed7aa39a.png">
<img width="1297" alt="Screen Shot 2020-06-26 at 10 30 26 AM" src="https://user-images.githubusercontent.com/37560903/85884829-172da200-b798-11ea-8810-1fc4f0db8b30.png">
