### PR TITLE
Setup dialogs in notification dialogs

### DIFF
--- a/assets/cms/js/page-notification.js
+++ b/assets/cms/js/page-notification.js
@@ -46,6 +46,10 @@ class PageNotification {
         this._$notificationsBox.find('.collapse').collapse('show')
     }
 
+    setupContent () {
+        this._$notificationsBox.find('.dialog-launch').dialog()
+    }
+
     clear () {
         this.innerStack.close()
         this.close()
@@ -75,6 +79,9 @@ class PageNotification {
         }
 
         const notice = PNotify.alert(notifyOptions)
+        notice.on('pnotify:afterOpen', () => {
+            notificationsBox.setupContent()
+        })
         notice.on('pnotify:afterClose', () => {
             if (notificationsBox.innerStack.length === 1) {
                 notificationsBox.close()


### PR DESCRIPTION
We need this to handle buttons and links in notifications with a `class="dialog-launch"` attribute.