### PR TITLE
Bump CKEditor from 4.15.1 to 4.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5248,9 +5248,9 @@
       }
     },
     "ckeditor4": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.15.1.tgz",
-      "integrity": "sha512-t2q61VG2h0i5DwZ+G3jTesrBSGnhNK0iKVdSzLBKx40PQzcDUDZOWJbMlpbAOuMzAAS096x5J2H4u/IyQRl1vQ=="
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.16.1.tgz",
+      "integrity": "sha512-dfclP3QDQfXMOrPex3s/l6b5E+MBSxhMpW3+nUM6lFX3ax1u/1tl2ETpe7iYJRtoN4TdvddL5XFweQT17woN5A=="
     },
     "class-utils": {
       "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap": "^4.5.3",
     "bootstrap-select": "^1.13.18",
     "bootstrap-tourist": "^0.3.2",
-    "ckeditor4": "^4.15.1",
+    "ckeditor4": "^4.16.1",
     "dropzone": "^5.7.2",
     "fullcalendar": "^3.10.2",
     "i": "^0.3.6",


### PR DESCRIPTION
Didn't make a PR for concrete5/concrete5 repo. I read this [documentation](https://documentation.concretecms.org/tutorials/submitting-user-interface-pull-requests-for-concrete5-version-9) but couldn't find the way how to apply updates of dependencies of bedrock on the main repo.