### PR TITLE
Bump CKEditor from 4.16.1 to 4.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "bootstrap": "^5.0.1",
         "bootstrap-select": "^1.14.0-beta2",
         "bootstrap-tourist": "^0.3.2",
-        "ckeditor4": "^4.16.1",
+        "ckeditor4": "^4.16.2",
         "ckeditor4-vue": "^1.3.2",
         "dropzone": "^5.7.2",
         "fullcalendar": "^3.10.2",
@@ -15484,7 +15484,6 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
       "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "extraneous": true,
-      "hasInstallScript": true,
       "dependencies": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap": "^5.0.1",
     "bootstrap-select": "^1.14.0-beta2",
     "bootstrap-tourist": "^0.3.2",
-    "ckeditor4": "^4.16.1",
+    "ckeditor4": "^4.16.2",
     "ckeditor4-vue": "^1.3.2",
     "dropzone": "^5.7.2",
     "fullcalendar": "^3.10.2",


### PR DESCRIPTION
CKEditor 4.16.2 has some security updates that are highly recommended to apply.

https://ckeditor.com/cke4/release-notes