### PR TITLE
Bump CKEditor from 4.16.2 to 4.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concretecms/bedrock",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concretecms/bedrock",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.1",
@@ -18,7 +18,7 @@
         "bootstrap": "^5.0.1",
         "bootstrap-select": "^1.14.0-beta2",
         "bootstrap-tourist": "git+https://git@github.com/concrete5/bootstrap-tourist.git",
-        "ckeditor4": "^4.16.2",
+        "ckeditor4": "^4.17.1",
         "ckeditor4-vue": "^1.3.2",
         "dropzone": "^5.7.2",
         "fullcalendar": "^3.10.2",
@@ -5305,9 +5305,9 @@
       }
     },
     "node_modules/ckeditor4": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.16.2.tgz",
-      "integrity": "sha512-5x2FmI+yGpQIKISh24Wp4HwjQxN6C4Lw59yh68HbFwcnMu8DvSiZLJfeINGvRG1oQ1L9GzJ5Pqd0PL0KDH08Jw=="
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.17.1.tgz",
+      "integrity": "sha512-VSTyro6tWd0B356SjJX8Zbix2Q85M/5h7469+vLb7DeNUP2vAimrPYoo29am2RRTTllyKxfLzVuTF8E9A1ssdA=="
     },
     "node_modules/ckeditor4-integrations-common": {
       "version": "0.2.0",
@@ -26440,9 +26440,9 @@
       }
     },
     "ckeditor4": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.16.2.tgz",
-      "integrity": "sha512-5x2FmI+yGpQIKISh24Wp4HwjQxN6C4Lw59yh68HbFwcnMu8DvSiZLJfeINGvRG1oQ1L9GzJ5Pqd0PL0KDH08Jw=="
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.17.1.tgz",
+      "integrity": "sha512-VSTyro6tWd0B356SjJX8Zbix2Q85M/5h7469+vLb7DeNUP2vAimrPYoo29am2RRTTllyKxfLzVuTF8E9A1ssdA=="
     },
     "ckeditor4-integrations-common": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap": "^5.0.1",
     "bootstrap-select": "^1.14.0-beta2",
     "bootstrap-tourist": "git+https://git@github.com/concrete5/bootstrap-tourist.git",
-    "ckeditor4": "^4.16.2",
+    "ckeditor4": "^4.17.1",
     "ckeditor4-vue": "^1.3.2",
     "dropzone": "^5.7.2",
     "fullcalendar": "^3.10.2",


### PR DESCRIPTION
CKEditor 4.17.0 has some security fixes that are highly recommended to apply.

https://ckeditor.com/cke4/release-notes