### PR TITLE
Add namespacing to core events

### DIFF
--- a/assets/cms/js/file-manager/file-manager.js
+++ b/assets/cms/js/file-manager/file-manager.js
@@ -28,8 +28,8 @@ class ConcreteFileManager {
             data: data,
             title: ccmi18n_filemanager.chooseFile,
             onOpen: function(dialog) {
-                ConcreteEvent.unsubscribe('FileManagerSelectFile')
-                ConcreteEvent.subscribe('FileManagerSelectFile', function(e, r) {
+                ConcreteEvent.unsubscribe('FileManagerSelectFile.core')
+                ConcreteEvent.subscribe('FileManagerSelectFile.core', function(e, r) {
                     var response = r || {}
                     if (!options.multipleSelection) {
                         response.fID = r.fID[0]


### PR DESCRIPTION
Other examples of adding a `core` namespace to these events incude:

* [UserSearchDialogSelectUser](https://github.com/concretecms/bedrock/blob/1.4.x/assets/cms/js/users/user-manager.js#L19) 
* [SelectGroup](https://github.com/concretecms/bedrock/blob/1.4.x/assets/cms/js/users/group-manager.js#L18)

According to jQuery ([source](https://api.jquery.com/off/)):

> If a simple event name such as "click" is provided, all events of
> that type (both direct and delegated) are removed from the elements in
> the jQuery set. When writing code that will be used as a plugin, or
> simply when working with a large code base, best practice is to attach
> and remove events using namespaces so that the code will not
> inadvertently remove event handlers attached by other code.

So by making this change, custom blocks which use the File Manager file selector can add handlers to this event which won't be unbound by unsubscribe here.