### PR TITLE
Make TomSelect show all values when selecting times in the calendar event modal

### DIFF
--- a/assets/calendar/js/backend/duration.js
+++ b/assets/calendar/js/backend/duration.js
@@ -133,8 +133,8 @@
             var my = this
             var $startTime = my.$element.find('select[data-select=start-time]')
             var $endTime = my.$element.find('select[data-select=end-time]')
-            var startTimeSelect = new TomSelect($startTime.get(0))
-            var endTimeSelect = new TomSelect($endTime.get(0))
+            var startTimeSelect = new TomSelect($startTime.get(0), { maxOptions: null })
+            var endTimeSelect = new TomSelect($endTime.get(0), { maxOptions: null })
 
             $startTime.data('TomSelect', startTimeSelect)
             $startTime.on('change', function () {

--- a/assets/calendar/js/backend/duration.js
+++ b/assets/calendar/js/backend/duration.js
@@ -131,10 +131,12 @@
 
         setupTimes: function () {
             var my = this
+            var config = {}
+            config.maxOptions = null
             var $startTime = my.$element.find('select[data-select=start-time]')
             var $endTime = my.$element.find('select[data-select=end-time]')
-            var startTimeSelect = new TomSelect($startTime.get(0), { maxOptions: null })
-            var endTimeSelect = new TomSelect($endTime.get(0), { maxOptions: null })
+            var startTimeSelect = new TomSelect($startTime.get(0), config)
+            var endTimeSelect = new TomSelect($endTime.get(0), config)
 
             $startTime.data('TomSelect', startTimeSelect)
             $startTime.on('change', function () {


### PR DESCRIPTION
Defaults to 50 when maxOptions not set, so only the first 50 times show up in the select menu (although you can type the time you want and it will show up as you type). This is similar to [this change](https://github.com/concretecms/bedrock/commit/b3848516e01bdc3cd213e1d6a190504a8947b3e9) for a similar problem in the site selector.