### PR TITLE
Fix concretecms/concretecms#12118

### DIFF
--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -310,8 +310,15 @@ ConcreteTree.prototype = {
     getSelectedNodeKeys: function (node, selected) {
         var my = this
 
-        // Initialize selected and deselected arrays
+        // Initialize selected array
         selected = selected || []
+
+        // Remove keys that are not in the tree anymore
+        selected = selected.filter(function (key) {
+            // return my.$element.fancytree('getNodeByKey', key) !== null
+            return $.ui.fancytree.getTree(my.$element).getNodeByKey(parseInt(key)) !== null
+        })
+
         // Walk through all child nodes
         if (node.hasChildren()) {
             node.getChildren().forEach(function (child) {

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -315,7 +315,6 @@ ConcreteTree.prototype = {
 
         // Remove keys that are not in the tree anymore
         selected = selected.filter(function (key) {
-            // return my.$element.fancytree('getNodeByKey', key) !== null
             return $.ui.fancytree.getTree(my.$element).getNodeByKey(parseInt(key)) !== null
         })
 


### PR DESCRIPTION
Some forms in the cms pass `[0]`, but we need to remove `0` as a selected key.

We can also fix this issue by changing `'selectNodesByKey': [<?php echo (int)$customTopicTreeNodeID?>],` to `'selectNodesByKey': <?php echo json_encode($customTopicTreeNodeID ? [$customTopicTreeNodeID] : []) ?>,` but many forms do same way (passing `[0]` if the value is `null` ), so it's better to fix it in the bedrock.