### PR TITLE
Fix concrete #12219

### DIFF
--- a/assets/icons/sprites.svg
+++ b/assets/icons/sprites.svg
@@ -146,11 +146,7 @@
                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <g id="Page-1" stroke="none" stroke-width="1" fill-rule="evenodd">
                 <g id="Dialog---Add-Page-List" transform="translate(-1021.000000, -105.000000)">
-                    <mask id="mask-2" fill="white">
-                        <use xlink:href="#path-1"></use>
-                    </mask>
-                    <use id="Rectangle" fill-opacity="0.6" xlink:href="#path-1"></use>
-                    <g id="Group" mask="url(#mask-2)">
+                    <g id="Group">
                         <g transform="translate(315.000000, 80.000000)">
                             <g id="icons8-info-(1)" stroke-width="1" fill="none" fill-rule="evenodd"
                                transform="translate(706.000000, 25.000000)">


### PR DESCRIPTION
In the icon spritesheet, the "icon-dialog-help" icon has an erroneous mask:
```
<mask id="mask-2" fill="white">
    <use xlink:href="#path-1"></use>
</mask>
<use id="Rectangle" fill-opacity="0.6" xlink:href="#path-1"></use>
```
  
The object "#path-1" is being linked, but does not exist anywhere. This causes the icon to fail to display on Firefox.  
Removing the mask, as well as the reference to it from the following <g> tag restores appearance in Firefox while also not affecting the visual appearance of the icon.