### PR TITLE
Fix concretecms/concretecms#12228

### DIFF
--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -139,9 +139,7 @@ ConcreteTree.prototype = {
             select: function (select, data) {
                 if (options.chooseNodeInForm) {
                     const keys = my.getSelectedNodeKeys(data.tree.getRootNode(), ajaxData.treeNodeSelectedIDs)
-                    if (keys.length) {
-                        options.onSelect(keys)
-                    }
+                    options.onSelect(keys)
                 }
             },
 

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -307,15 +307,18 @@ ConcreteTree.prototype = {
         })
     },
 
+    // Fancytree provides a selected keys array, but it doesn't include the children of closed categories.
+    // So we need to walk through the entire tree to get all selected nodes.
     getSelectedNodeKeys: function (node, selected) {
         var my = this
 
         // Initialize selected array
         selected = selected || []
 
-        // Remove keys that are not in the tree anymore
-        selected = selected.filter(function (key) {
-            return $.ui.fancytree.getTree(my.$element).getNodeByKey(parseInt(key)) !== null
+        // We need to remove 0 as a selected key, because sometimes it comes from php and means null.
+        // See: https://github.com/concretecms/concretecms/issues/12118
+        selected = selected.filter(function (value) {
+            return parseInt(value) > 0
         })
 
         // Walk through all child nodes


### PR DESCRIPTION
This PR fixes https://github.com/concretecms/concretecms/issues/12228
In #343, I recreated the same bug as https://github.com/concretecms/concretecms/issues/11862
So, this PR is another way to fix https://github.com/concretecms/concretecms/issues/12118

As I said before, some concrete forms pass `[0]` when the selected topic value is `null` .
This time, I am just checking to see if the node keys are larger than `0` .