### PR TITLE
Fix concretecms/concretecms#12200

### DIFF
--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -147,7 +147,7 @@ ConcreteTree.prototype = {
                     }
                     // Call onSelect callback
                     options.onSelect(keys)
-                    // Update selected nodes for ajax request to avoid hidden nodes to be deselected
+                    // Update selected nodes for ajax request to avoid hidden nodes to be selected unexpectedly
                     ajaxData.treeNodeSelectedIDs = keys
                 }
             },

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -226,11 +226,13 @@ ConcreteTree.prototype = {
             },
             collapse: function(event, data) {
                 // loop over child nodes and check if node is still selected. If not remove it from the 'options.ajaxData.selected' array.
+                if (options.ajaxData.selected) {
                 data.node.children.forEach(function(nodeChild) {
                     if (options.ajaxData.selected.includes(parseInt(nodeChild.key)) && !nodeChild.isSelected()) {
                         options.ajaxData.selected.splice(options.ajaxData.selected.indexOf(nodeChild.key), 1)
                     }
                 })
+                }
             },
             dnd: {
                 preventRecursiveMoves: true, // Prevent dropping nodes on own descendants,


### PR DESCRIPTION
This PR fixes https://github.com/concretecms/concretecms/issues/12200

## Why this issue didn't happen before version 9?

Because we expanded full tree nodes. Since version 9, we changed to close category nodes initially.

## Why this issue didn't happen before #327 ?

Because hidden nodes inside the category nodes weren't selected correctly.
After this PR, those nodes are selected as expected, but I didn't care about single select mode.

## What has changed in this PR?

Now, we support the single select mode correctly.
When the select mode is single, we should check and deselect all hidden nodes.
When the select mode is multiple, we should check all hidden nodes and get keys if they are selected.