### PR TITLE
Let getFileDetails return null in case of errors

### DIFF
--- a/assets/ckeditor/js/concrete/file-manager.js
+++ b/assets/ckeditor/js/concrete/file-manager.js
@@ -15,6 +15,9 @@
                             jQuery.fn.dialog.showLoader()
                             ConcreteFileManager.getFileDetails(data.fID, function (r) {
                                 jQuery.fn.dialog.hideLoader()
+                                if (!r) {
+                                    return
+                                }
                                 var file = r.files[0]
                                 if ((dialog.getName() == 'image' || dialog.getName() == 'image2') && dialog._.currentTabId == 'info') {
                                     CKEDITOR.tools.callFunction(editor._.filebrowserFn, file.urlInline, function () {

--- a/assets/cms/components/form/ConcreteFileInput.vue
+++ b/assets/cms/components/form/ConcreteFileInput.vue
@@ -121,10 +121,10 @@ export default {
             var my = this
             my.isLoading = true
             ConcreteFileManager.getFileDetails(fileId, function (r) {
-                my.selectedFile = r.files[0]
-                my.selectedFileID = fileId
+                my.selectedFile = r ? r.files[0] : null
+                my.selectedFileID = r ? fileId : 0
                 my.isLoading = false
-                my.$emit('selectedfile', r.files[0])
+                my.$emit('selectedfile', my.selectedFile)
             })
         }
 

--- a/assets/cms/components/gallery/GalleryEdit.vue
+++ b/assets/cms/components/gallery/GalleryEdit.vue
@@ -183,7 +183,7 @@ export default {
             ConcreteFileManager.launchDialog(function(data) {
                 for (var fID of data.fID) {
                     ConcreteFileManager.getFileDetails(fID, function (file) {
-                        file = file.files[0] || {}
+                        file = file?.files[0] || {}
                         me.gallery.push({
                             id: file.fID,
                             title: file.title,

--- a/assets/cms/js/file-manager/file-manager.js
+++ b/assets/cms/js/file-manager/file-manager.js
@@ -51,6 +51,7 @@ class ConcreteFileManager {
             data: { fID: fID },
             error: function(r) {
                 ConcreteAlert.dialog(ccmi18n.error, r.responseText)
+                callback(null)
             },
             success: function(r) {
                 callback(r)


### PR DESCRIPTION
This is an an alternative fix for https://github.com/concretecms/concretecms/issues/12706, superseding https://github.com/concretecms/concretecms/pull/12707
