### PR TITLE
Add ConcreteFetch that uses window.fetch() instead of jQuery.ajax()

### DIFF
--- a/assets/cms/js/fetch.js
+++ b/assets/cms/js/fetch.js
@@ -1,0 +1,206 @@
+;(function(global) {
+    'use strict'
+
+    /**
+     * Recursively add fields to URLSearchParams.
+     * Used by buildRequestBody().
+     *
+     * @param {string} prefix
+     * @param {Record|Array|any} value
+     * @param {URLSearchParams} urlSearchParams
+     *
+     * @returns {void}
+     */
+    function addToUrlSearchParams(prefix, value, urlSearchParams) {
+        if (value === null || value === undefined || typeof value !== 'object') {
+            return;
+        }
+        if (!prefix && Array.isArray(value)) {
+            return;
+        }
+        for (const [key, val] of Object.entries(value)) {
+            if (val === null || val === undefined) {
+                continue;
+            }
+            const fieldName = prefix ? `${prefix}[${key}]` : key;
+            if (typeof val === 'object') {
+                addToUrlSearchParams(fieldName, val, urlSearchParams);
+            } else {
+                urlSearchParams.append(fieldName, String(val));
+            }
+        }
+    }
+
+    /**
+     * Build the request body for an AJAX request.
+     *
+     * @param {Record|any} data The object to build the body from
+     *
+     * @returns {URLSearchParams} The request body
+     *
+     * @example
+     * buildRequestBody({key: 'value', arr: [1, 2, 3], nested: {a: 'b'}})
+     */
+    function buildRequestBody(data) {
+        const urlSearchParams = new URLSearchParams();
+        addToUrlSearchParams('', data, urlSearchParams);
+        return urlSearchParams;
+    }
+
+    /**
+     * Prepare the request options for fetch().
+     *
+     * @param {RequestInit|Record<string, any>|null|undefined} request
+     * @param {Record<string, string>|null|undefined} headers Additional headers to add (will not override existing ones)
+     *
+     * @returns {RequestInit}
+     */
+    function prepareRequest(request, headers) {
+        if (request) {
+            try {
+                request = structuredClone(request);
+            } catch {}
+        } else {
+            request = {};
+        }
+        // Default to GET if no method is specified
+        request.method = String(request.method || 'GET').toUpperCase();
+        if (request.body?.constructor === Object) {
+            // Convert body object to URLSearchParams
+            request.body = buildRequestBody(request.body);
+        }
+        if (!request.headers) {
+            request.headers = {};
+        }
+        if (!request.cache && request.method !== 'GET') {
+            // Disable caching for non-GET requests by default
+            request.cache = 'no-cache';
+        }
+        const existingHeaderKeys = Object.keys(request.headers).map((key) => key.toLowerCase());
+        if (headers) {
+            for (const [name, value] of Object.entries(headers)) {
+                const lowerCaseName = name.toLowerCase();
+                if (!existingHeaderKeys.includes(lowerCaseName)) {
+                    request.headers[name] = value;
+                    existingHeaderKeys.push(lowerCaseName);
+                }
+            }
+        }
+        if (!existingHeaderKeys.includes('x-requested-with')) {
+            // Just to let the server know this is an AJAX request
+            request.headers['X-Requested-With'] = 'XMLHttpRequest';
+        }
+        if (request.method !== 'GET' && request.body && !existingHeaderKeys.includes('content-type')) {
+            // We want to use $_POST on the server side
+            request.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+        }
+        return request;
+    }
+
+    /**
+     * Fetch JSON data from a URL.
+     *
+     * @param {string} url The URL to fetch data from
+     * @param {RequestInit|Record<string, any>|null|undefined} request The request options and body
+     *
+     * @throws {Error} If the response contains an error or is not ok
+     *
+     * @returns {Promise<any>} The JSON response
+     *
+     * @example
+     * try {
+     *     const data = await fetchJson('/api/data', {
+     *         method: 'POST',
+     *         body: {
+     *             key: 'value'
+     *         }
+     *     });
+     * } catch (error) {
+     *     window.alert(error.message);
+     * }
+     */
+    async function fetchJson(url, request) {
+        request = prepareRequest(request, {Accept: 'application/json'});
+        const response = await fetch(url, request);
+        const responseText = await response.text();
+        let responseData;
+        try {
+            responseData = JSON.parse(responseText);
+        } catch {
+            throw new Error(responseText);
+        }
+        if (responseData?.errors?.length) {
+            throw new Error(responseData.errors[0]);
+        }
+        if (responseData?.error) {
+            throw new Error(responseData.error);
+        }
+        if (!response.ok) {
+            throw new Error(responseText);
+        }
+        return responseData;
+    }
+
+    /**
+     * Fetch an HTML chunk from a URL.
+     *
+     * @param {string} url The URL to fetch data from
+     * @param {RequestInit|Record<string, any>|undefined} request The request options and body
+     *
+     * @throws {Error} If the response contains an error or is not ok
+     *
+     * @returns {Promise<string>} The HTML response
+     *
+     * @example
+     * try {
+     *     const data = await fetchHtml('/api/render', {
+     *         method: 'POST',
+     *         body: {
+     *             key: 'value'
+     *         }
+     *     });
+     * } catch (error) {
+     *     window.alert(error.message);
+     * }
+     */
+    async function fetchHtml(url, request) {
+        request = prepareRequest(
+            request,
+            {
+                Accept: [
+                    // Prefer HTML
+                    'text/html',
+                    // ... but accept JSON in case of errors
+                    'application/json;q=0.9',
+                    // ... or plain text as a last resort fallback
+                    'text/plain;q=0.8',
+                ].join(', ')
+            }
+        );
+        const response = await fetch(url, request);
+        const responseText = await response.text();
+        try {
+            // Try to see if it's JSON with errors
+            const responseData = JSON.parse(responseText);
+            if (responseData?.errors?.length) {
+                throw new Error(responseData.errors[0]);
+            }
+            if (responseData?.error) {
+                throw new Error(responseData.error);
+            }
+        } catch {
+            // Not JSON, that's fine
+        }
+        if (!response.ok) {
+            throw new Error(responseText);
+        }
+        return responseText;
+    }
+
+    global.ConcreteFetch = {
+        buildRequestBody,
+        fetchJson,
+        fetchHtml,
+    };
+
+})(global);

--- a/assets/cms/js/fetch.js
+++ b/assets/cms/js/fetch.js
@@ -13,20 +13,20 @@
      */
     function addToUrlSearchParams(prefix, value, urlSearchParams) {
         if (value === null || value === undefined || typeof value !== 'object') {
-            return;
+            return
         }
         if (!prefix && Array.isArray(value)) {
-            return;
+            return
         }
         for (const [key, val] of Object.entries(value)) {
             if (val === null || val === undefined) {
-                continue;
+                continue
             }
-            const fieldName = prefix ? `${prefix}[${key}]` : key;
+            const fieldName = prefix ? `${prefix}[${key}]` : key
             if (typeof val === 'object') {
-                addToUrlSearchParams(fieldName, val, urlSearchParams);
+                addToUrlSearchParams(fieldName, val, urlSearchParams)
             } else {
-                urlSearchParams.append(fieldName, String(val));
+                urlSearchParams.append(fieldName, String(val))
             }
         }
     }
@@ -42,9 +42,9 @@
      * buildRequestBody({key: 'value', arr: [1, 2, 3], nested: {a: 'b'}})
      */
     function buildRequestBody(data) {
-        const urlSearchParams = new URLSearchParams();
-        addToUrlSearchParams('', data, urlSearchParams);
-        return urlSearchParams;
+        const urlSearchParams = new URLSearchParams()
+        addToUrlSearchParams('', data, urlSearchParams)
+        return urlSearchParams
     }
 
     /**
@@ -58,43 +58,43 @@
     function prepareRequest(request, headers) {
         if (request) {
             try {
-                request = structuredClone(request);
+                request = global.structuredClone(request)
             } catch {}
         } else {
-            request = {};
+            request = {}
         }
         // Default to GET if no method is specified
-        request.method = String(request.method || 'GET').toUpperCase();
+        request.method = String(request.method || 'GET').toUpperCase()
         if (request.body?.constructor === Object) {
             // Convert body object to URLSearchParams
-            request.body = buildRequestBody(request.body);
+            request.body = buildRequestBody(request.body)
         }
         if (!request.headers) {
-            request.headers = {};
+            request.headers = {}
         }
         if (!request.cache && request.method !== 'GET') {
             // Disable caching for non-GET requests by default
-            request.cache = 'no-cache';
+            request.cache = 'no-cache'
         }
-        const existingHeaderKeys = Object.keys(request.headers).map((key) => key.toLowerCase());
+        const existingHeaderKeys = Object.keys(request.headers).map((key) => key.toLowerCase())
         if (headers) {
             for (const [name, value] of Object.entries(headers)) {
-                const lowerCaseName = name.toLowerCase();
+                const lowerCaseName = name.toLowerCase()
                 if (!existingHeaderKeys.includes(lowerCaseName)) {
-                    request.headers[name] = value;
-                    existingHeaderKeys.push(lowerCaseName);
+                    request.headers[name] = value
+                    existingHeaderKeys.push(lowerCaseName)
                 }
             }
         }
         if (!existingHeaderKeys.includes('x-requested-with')) {
             // Just to let the server know this is an AJAX request
-            request.headers['X-Requested-With'] = 'XMLHttpRequest';
+            request.headers['X-Requested-With'] = 'XMLHttpRequest'
         }
         if (request.method !== 'GET' && request.body && !existingHeaderKeys.includes('content-type')) {
             // We want to use $_POST on the server side
-            request.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+            request.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
         }
-        return request;
+        return request
     }
 
     /**
@@ -106,14 +106,14 @@
      */
     function checkJsonResponse(responseData) {
         if (responseData?.errors?.length) {
-            const error = new Error(responseData.errors[0]);
-            error.responseData = responseData;
-            throw error;
+            const error = new Error(responseData.errors[0])
+            error.responseData = responseData
+            throw error
         }
         if (responseData?.error) {
-            const error = new Error(responseData.error);
-            error.responseData = responseData;
-            throw error;
+            const error = new Error(responseData.error)
+            error.responseData = responseData
+            throw error
         }
     }
 
@@ -140,20 +140,20 @@
      * }
      */
     async function fetchJson(url, request) {
-        request = prepareRequest(request, {Accept: 'application/json'});
-        const response = await fetch(url, request);
-        const responseText = await response.text();
-        let responseData;
+        request = prepareRequest(request, { Accept: 'application/json' })
+        const response = await fetch(url, request)
+        const responseText = await response.text()
+        let responseData
         try {
-            responseData = JSON.parse(responseText);
+            responseData = JSON.parse(responseText)
         } catch {
-            throw new Error(responseText);
+            throw new Error(responseText)
         }
-        checkJsonResponse(responseData);
+        checkJsonResponse(responseData)
         if (!response.ok) {
-            throw new Error(responseText);
+            throw new Error(responseText)
         }
-        return responseData;
+        return responseData
     }
 
     /**
@@ -188,34 +188,33 @@
                     // ... but accept JSON in case of errors
                     'application/json;q=0.9',
                     // ... or plain text as a last resort fallback
-                    'text/plain;q=0.8',
+                    'text/plain;q=0.8'
                 ].join(', ')
             }
-        );
-        const response = await fetch(url, request);
-        const responseText = await response.text();
+        )
+        const response = await fetch(url, request)
+        const responseText = await response.text()
         let responseData
         try {
             // Try to see if it's JSON with errors
-            responseData = JSON.parse(responseText);
+            responseData = JSON.parse(responseText)
         } catch {
             // Not JSON, that's fine
-            responseData = null;
+            responseData = null
         }
         if (responseData) {
-            checkJsonResponse(responseData);
+            checkJsonResponse(responseData)
         }
 
         if (!response.ok) {
-            throw new Error(responseText);
+            throw new Error(responseText)
         }
-        return responseText;
+        return responseText
     }
 
     global.ConcreteFetch = {
         buildRequestBody,
         json: fetchJson,
-        html: fetchHtml,
-    };
-
-})(global);
+        html: fetchHtml
+    }
+})(global)

--- a/assets/cms/js/fetch.js
+++ b/assets/cms/js/fetch.js
@@ -98,6 +98,26 @@
     }
 
     /**
+     * Check a JSON response for errors.
+     *
+     * @param {any} responseData
+     *
+     * @throws {Error} If the response data contains errors (the thrown error will have a responseData property)
+     */
+    function checkJsonResponse(responseData) {
+        if (responseData?.errors?.length) {
+            const error = new Error(responseData.errors[0]);
+            error.responseData = responseData;
+            throw error;
+        }
+        if (responseData?.error) {
+            const error = new Error(responseData.error);
+            error.responseData = responseData;
+            throw error;
+        }
+    }
+
+    /**
      * Fetch JSON data from a URL.
      *
      * @param {string} url The URL to fetch data from
@@ -129,12 +149,7 @@
         } catch {
             throw new Error(responseText);
         }
-        if (responseData?.errors?.length) {
-            throw new Error(responseData.errors[0]);
-        }
-        if (responseData?.error) {
-            throw new Error(responseData.error);
-        }
+        checkJsonResponse(responseData);
         if (!response.ok) {
             throw new Error(responseText);
         }
@@ -179,18 +194,18 @@
         );
         const response = await fetch(url, request);
         const responseText = await response.text();
+        let responseData
         try {
             // Try to see if it's JSON with errors
-            const responseData = JSON.parse(responseText);
-            if (responseData?.errors?.length) {
-                throw new Error(responseData.errors[0]);
-            }
-            if (responseData?.error) {
-                throw new Error(responseData.error);
-            }
+            responseData = JSON.parse(responseText);
         } catch {
             // Not JSON, that's fine
+            responseData = null;
         }
+        if (responseData) {
+            checkJsonResponse(responseData);
+        }
+
         if (!response.ok) {
             throw new Error(responseText);
         }

--- a/assets/cms/js/fetch.js
+++ b/assets/cms/js/fetch.js
@@ -48,7 +48,7 @@
     }
 
     /**
-     * Prepare the request options for fetch().
+     * Prepare the request options for window.fetch().
      *
      * @param {RequestInit|Record<string, any>|null|undefined} request
      * @param {Record<string, string>|null|undefined} headers Additional headers to add (will not override existing ones)
@@ -199,8 +199,8 @@
 
     global.ConcreteFetch = {
         buildRequestBody,
-        fetchJson,
-        fetchHtml,
+        json: fetchJson,
+        html: fetchHtml,
     };
 
 })(global);


### PR DESCRIPTION
What about using [`window.fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) instead of [`jQuery.ajax()`](https://api.jquery.com/jQuery.ajax/) to perform ajax requests?

For example, the [following code](https://github.com/concretecms/concretecms/blob/9.4.5/concrete/elements/permission/clipboard.php#L44-L63):

```js
$('#ccm-permissions-list-paste-permissions-<?= $uid ?>').click(function() {
    jQuery.fn.dialog.showLoader();
    var frm = $(this).closest('.ccm-permission-grid');
    var data = 'pkCategoryHandle=' + frm.find('input[name=pkCategoryHandle]').val();
    $.ajax({
        dataType: 'json',
        type: 'post',
        data: data,
        url: <?= json_encode($resolverManager->resolve(['/ccm/system/permissions/set/paste']) . '?' . $valt->getParameter('paste_permission_set')) ?>,
        success: function(r) {
            jQuery.fn.dialog.hideLoader();
            for (i = 0; i < r.length; i++) {
                var cell = r[i];
                $('#ccm-permission-grid-cell-' + cell.pkID).html(cell.html);
                $('#ccm-permission-grid-name-' + cell.pkID + ' a').attr('data-paID', cell.paID);        
            }

        }                
    })
})
```

could be written (with added error handling) as:

```js
$('#ccm-permissions-list-paste-permissions-<?= $uid ?>').click(async function() {
    jQuery.fn.dialog.showLoader();
    try {
        var frm = $(this).closest('.ccm-permission-grid');
        const cells = await ConcreteFetch.fetchJson(
            <?= json_encode($resolverManager->resolve(['/ccm/system/permissions/set/paste']) . '?' . $valt->getParameter('paste_permission_set')) ?>,
            {
                method: 'POST',
                body: {
                    pkCategoryHandle: frm.find('input[name=pkCategoryHandle]').val(),
                },
            }
        );
        cells.forEach(function(cell) {
            $('#ccm-permission-grid-cell-' + cell.pkID).html(cell.html);
            $('#ccm-permission-grid-name-' + cell.pkID + ' a').attr('data-paID', cell.paID);
        });
    } catch (e) {
        ConcreteAlert.error({message: e.message, plainTextMessage: true});
    } finally {
        jQuery.fn.dialog.hideLoader();
    }
});
```
