### PR TITLE
Fix cross-area drag for containers and layouts

### DIFF
--- a/assets/cms/js/edit-mode/block.js
+++ b/assets/cms/js/edit-mode/block.js
@@ -121,11 +121,12 @@
             var my = this
             var targetDragAreas = targetArea.getDragAreas()
             var myElem
+            var containerWrapper = my.getContainer()
 
             afterBlock = afterBlock || null
             my.getArea().removeBlock(my)
-            my.getContainer().remove()
             if (my.getWraps()) {
+                containerWrapper.remove()
                 myElem = $(targetArea.getBlockTemplate()())
                 if (myElem.children().length) {
                     myElem.find('div.block').replaceWith(my.getElem())
@@ -133,7 +134,7 @@
                     myElem.append(my.getElem())
                 }
             } else {
-                myElem = my.getElem()
+                myElem = containerWrapper.detach()
             }
             if (targetDragAreas.length > 0) {
                 var targetDragArea
@@ -603,7 +604,9 @@
          * @param areas
          */
         setupAreaDragPayloads: function setupAreaDragPayloads(areas) {
+            var ownElem = this.getElem()[0]
             _(areas).map((area) => {
+                if (ownElem.contains(area.getElem()[0])) return
                 if (area.acceptsBlockType(this.getHandle())) {
                     area.getElem().addClass('ccm-area-accepts-block-drag-payload')
                 }

--- a/assets/cms/js/edit-mode/containerblock.js
+++ b/assets/cms/js/edit-mode/containerblock.js
@@ -33,6 +33,14 @@ import _ from 'underscore'
 
         bindNotchMenu: function() {
             var my = this
+            // Remove stale ConcreteMenu event handlers left by previous
+            // instances. ContainerBlock doesn't store a reference to its
+            // ConcreteMenu, so it isn't destroyed during scanBlocks reset.
+            // Without this cleanup, mousemove.concreteMenu handlers
+            // accumulate on the notch across drag cycles, causing the
+            // click-proxy overlay to be re-established over the notch
+            // even after it's been reset.
+            my.getNotch().off('.concreteMenu')
             var menu_config = {
                 highlightClassName: 'ccm-edit-mode-title-notch-highlight',
                 menuActiveClass: 'ccm-edit-mode-title-notch-highlight',
@@ -54,11 +62,6 @@ import _ from 'underscore'
                 e.preventDefault()
                 my.delete()
             })
-        },
-
-        setupAreaDragPayloads: function setupAreaDragPayloads(areas) {
-            var my = this
-            my.getArea().getElem().addClass('ccm-area-accepts-block-drag-payload')
         },
 
         bindEditDesign: function ContainerBlockEditDesign() {
@@ -83,6 +86,10 @@ import _ from 'underscore'
             var my = this
             var mover = my.getNotch().find('a[data-inline-command=move-block]').parent()
 
+            // Ensure the drag handle paints above the ConcreteMenu click-proxy
+            // overlay (z-index 500). Without this, the proxy intercepts mousedown
+            // events and pep never sees them.
+            mover.css({ position: 'relative', zIndex: 501 })
             $.pep.unbind(mover)
             mover.pep(my.getPepSettings())
         }

--- a/assets/cms/js/edit-mode/editmode.js
+++ b/assets/cms/js/edit-mode/editmode.js
@@ -336,11 +336,10 @@
                 var areas = my.getAreas()
                 var contenders
 
-                if (block instanceof Concrete.Layout || block instanceof Concrete.ContainerBlock) {
-                    areas = [_(areas).find(function (a) {
-                        return block.getArea() === a
-                    })]
-                }
+                var ownElem = block.getElem()[0]
+                areas = _(areas).filter(function (area) {
+                    return !ownElem.contains(area.getElem()[0])
+                })
 
                 contenders = _.flatten(_(areas).map(function (area) {
                     var drag_areas = area.contendingDragAreas(pep, block)

--- a/assets/cms/js/edit-mode/layout.js
+++ b/assets/cms/js/edit-mode/layout.js
@@ -29,6 +29,7 @@ import _ from 'underscore'
 
         bindNotchMenu: function() {
             var my = this
+            my.getNotch().off('.concreteMenu')
             var $menuElem = $('[data-layout-menu=' + my.getId() + ']')
             var menu_config = {
                 highlightClassName: 'ccm-edit-mode-title-notch-highlight',
@@ -77,14 +78,9 @@ import _ from 'underscore'
         bindDrag: function layoutBindDrag() {
             var my = this
             var peper = $('[data-layout-command="move-block"]')
+            peper.css({ position: 'relative', zIndex: 501 })
             $.pep.unbind(peper)
             peper.pep(my.getPepSettings())
-        },
-
-        setupAreaDragPayloads: function setupAreaDragPayloads(areas) {
-            var my = this
-
-            my.getArea().getElem().addClass('ccm-area-accepts-block-drag-payload')
         },
 
         addToDragArea: function layoutAddToDragArea() {


### PR DESCRIPTION
Fixes #403

Containers and layouts could only be sorted within their current area. Dragging them to a different area silently failed — no drop target ever appeared. Four issues fixed:

1. **Drop target marking** — ContainerBlock and Layout overrode `setupAreaDragPayloads` to mark only the current area. Deleted the overrides and added a descendant-aware `Element.contains()` check to the base `Block` class instead. Self-nesting is still prevented; all other accepting areas are now valid drop targets.

2. **Contender selection** — The `EditModeBlockDrag` handler replaced the area list with just the current area for Layout/ContainerBlock instances. Replaced with the same universal descendant filter, removing the `instanceof` special-casing.

3. **Notch preservation** — `Block.move()` destroyed the sibling notch wrapper during cross-area moves. For non-wrapping blocks, the entire container wrapper is now `detach()`ed and reinserted as a unit.

4. **Drag handle z-index** — The ConcreteMenu click-proxy overlay (z-index 500) could end up covering the drag handle after a move. The drag handle now gets `position: relative; z-index: 501`. Also cleans up stale ConcreteMenu handlers in `bindNotchMenu()`.

**Companion PR:** concretecms/concretecms#12865 adds sub-area handle migration to `processArrangement()` so that blocks inside a moved container's sub-areas don't get orphaned. I'd recommend merging the concretecms PR first — it's dormant until this bedrock PR enables cross-area drag.

See also concretecms/concretecms#11442 for the broader container workflow discussion.