### PR TITLE
Prevent duplicate HTTP requests when selecting a file

### DIFF
--- a/assets/cms/components/form/ConcreteFileInput.vue
+++ b/assets/cms/components/form/ConcreteFileInput.vue
@@ -110,7 +110,7 @@ export default {
                 options.filters = my.filters
             }
             ConcreteFileManager.launchDialog(function(r) {
-                my.loadFile(r.fID)
+                my.selectedFileID = r.fID
             }, options)
         },
         clearFile: function() {


### PR DESCRIPTION
This fixes an issue where selecting a file triggered duplicate HTTP requests in ConcreteFileInput. The selected file ID is now updated first so the existing flow handles the file load only once.