### PR TITLE
Fix #11705 - replace Browse Server with Select file in editor dialogs

### DIFF
--- a/assets/ckeditor/js/concrete/file-manager.js
+++ b/assets/ckeditor/js/concrete/file-manager.js
@@ -1,4 +1,5 @@
-/* eslint-disable eqeqeq */
+/* eslint-disable eqeqeq, camelcase */
+/* global ccmi18n_editor */
 (function () {
     CKEDITOR.plugins.add('concretefilemanager', {
         requires: 'filebrowser',
@@ -65,6 +66,10 @@
                     if (browseButton !== null) {
                         browseButton.hidden = false
                         browseButton.onClick = makeButtonClickHandler()
+                        if (typeof ccmi18n_editor !== 'undefined' && ccmi18n_editor.selectFile) {
+                            browseButton.label = ccmi18n_editor.selectFile
+                            browseButton.title = ccmi18n_editor.selectFile
+                        }
                     }
                 }
             })


### PR DESCRIPTION
The "Browse Server" button across CKEditor dialogs reads as developer jargon to non-developer content editors. The issue at concretecms/concretecms#11705 proposes a clearer label; mlocati's suggested wording in the comments is "Select file" — pairs well with "Select page" on the link dialog (handled by the concretecms companion PR).

The `concretefilemanager` plugin already loops every tab in every CKEditor dialog and intercepts the `'browse'` button (currently overrides `hidden` and `onClick`). This adds two more lines in the same loop to override `label` and `title` to `ccmi18n_editor.selectFile`. One spot, all dialogs:

- Link dialog
- Image dialog (Image Info tab and Link tab)
- Image2 dialog (Enhanced Image plugin)
- Document Properties dialog (background image picker)

The override is gated on `typeof ccmi18n_editor !== 'undefined' && ccmi18n_editor.selectFile`, so if this PR lands before the concretecms companion (which defines that key), the existing CKEditor "Browse Server" label keeps showing. No flicker either way.

The new label flows through the same `t()` translation pipeline as every other Concrete-defined i18n string — community translation extraction will pick up "Select file" in the next round, and English falls through until a locale provides a translation.

Fixes concretecms/concretecms#11705