### PR TITLE
Fix container notch and move control disappearing after a move

### DIFF
--- a/assets/cms/js/edit-mode/block.js
+++ b/assets/cms/js/edit-mode/block.js
@@ -121,11 +121,12 @@
             var my = this
             var targetDragAreas = targetArea.getDragAreas()
             var myElem
+            var containerWrapper = my.getContainer()
 
             afterBlock = afterBlock || null
             my.getArea().removeBlock(my)
-            my.getContainer().remove()
             if (my.getWraps()) {
+                containerWrapper.remove()
                 myElem = $(targetArea.getBlockTemplate()())
                 if (myElem.children().length) {
                     myElem.find('div.block').replaceWith(my.getElem())
@@ -133,7 +134,7 @@
                     myElem.append(my.getElem())
                 }
             } else {
-                myElem = my.getElem()
+                myElem = containerWrapper.detach()
             }
             if (targetDragAreas.length > 0) {
                 var targetDragArea

--- a/assets/cms/js/edit-mode/containerblock.js
+++ b/assets/cms/js/edit-mode/containerblock.js
@@ -33,6 +33,14 @@ import _ from 'underscore'
 
         bindNotchMenu: function() {
             var my = this
+            // Remove stale ConcreteMenu event handlers left by previous
+            // instances. ContainerBlock doesn't store a reference to its
+            // ConcreteMenu, so it isn't destroyed during scanBlocks reset.
+            // Without this cleanup, mousemove.concreteMenu handlers
+            // accumulate on the notch across drag cycles, causing the
+            // click-proxy overlay to be re-established over the notch
+            // even after it's been reset.
+            my.getNotch().off('.concreteMenu')
             var menu_config = {
                 highlightClassName: 'ccm-edit-mode-title-notch-highlight',
                 menuActiveClass: 'ccm-edit-mode-title-notch-highlight',
@@ -83,6 +91,10 @@ import _ from 'underscore'
             var my = this
             var mover = my.getNotch().find('a[data-inline-command=move-block]').parent()
 
+            // Ensure the drag handle paints above the ConcreteMenu click-proxy
+            // overlay (z-index 500). Without this, the proxy intercepts mousedown
+            // events and pep never sees them.
+            mover.css({ position: 'relative', zIndex: 501 })
             $.pep.unbind(mover)
             mover.pep(my.getPepSettings())
         }

--- a/assets/cms/js/edit-mode/layout.js
+++ b/assets/cms/js/edit-mode/layout.js
@@ -29,6 +29,9 @@ import _ from 'underscore'
 
         bindNotchMenu: function() {
             var my = this
+            // Clear stale ConcreteMenu handlers so the click-proxy overlay isn't
+            // re-established over the notch across drag cycles.
+            my.getNotch().off('.concreteMenu')
             var $menuElem = $('[data-layout-menu=' + my.getId() + ']')
             var menu_config = {
                 highlightClassName: 'ccm-edit-mode-title-notch-highlight',
@@ -77,6 +80,9 @@ import _ from 'underscore'
         bindDrag: function layoutBindDrag() {
             var my = this
             var peper = $('[data-layout-command="move-block"]')
+            // Paint the drag handle above the ConcreteMenu click-proxy overlay
+            // (z-index 500) so it can receive mousedown.
+            peper.css({ position: 'relative', zIndex: 501 })
             $.pep.unbind(peper)
             peper.pep(my.getPepSettings())
         },


### PR DESCRIPTION
Fixes concretecms/concretecms#12353.

When you move a container, its title notch and move control vanish until you reload the page. That's the first bug below. While I was in here I also fixed a related one where the move handle stays put but stops responding to clicks.

1. **The notch disappears when you move a block.** `Block.move()` called `my.getContainer().remove()` and then, for a non-wrapping block, re-inserted only the inner element — so the container wrapper that carries the notch (and its move control) got thrown away. Now the wrapper is captured up front and `detach()`ed instead, so it survives the move and goes back in as a unit.

2. **The drag handle stops responding.** The ConcreteMenu click-proxy overlay (z-index 500) could end up painted over the notch's move handle, swallowing the mousedown so pep never starts a drag. Two parts: `bindNotchMenu()` clears stale `.concreteMenu` handlers that pile up across drag cycles (ContainerBlock and Layout don't keep a reference to their menu, so it isn't torn down on `scanBlocks` reset), and the move handle gets `position: relative; z-index: 501` so it paints above the proxy.

Both show up on plain within-area sorting — bug 1 is the exact repro in the issue.
